### PR TITLE
Fix stopping daemon threads in Python >= 3.7

### DIFF
--- a/neptune/internal/channels/channels_values_sender.py
+++ b/neptune/internal/channels/channels_values_sender.py
@@ -105,7 +105,7 @@ class ChannelsValuesSendingThread(NeptuneThread):
         self._values_batch = []
 
     def run(self):
-        while not self.is_interrupted() or not self._values_queue.empty():
+        while self.should_continue_running() or not self._values_queue.empty():
             try:
                 sleep_start = time.time()
                 self._values_batch.append(self._values_queue.get(timeout=max(self._sleep_time, 0)))
@@ -121,10 +121,6 @@ class ChannelsValuesSendingThread(NeptuneThread):
                 self._process_batch()
 
         self._process_batch()
-
-    def join(self, timeout=None):
-        self.interrupt()
-        super(ChannelsValuesSendingThread, self).join(timeout)
 
     def _process_batch(self):
         send_start = time.time()

--- a/neptune/internal/threads/aborting_thread.py
+++ b/neptune/internal/threads/aborting_thread.py
@@ -30,7 +30,7 @@ class AbortingThread(NeptuneThread):
 
     def run(self):
         try:
-            while not self.is_interrupted():
+            while self.should_continue_running():
                 raw_message = self._ws_client.recv()
                 self._abort_message_processor.run(raw_message)
         except WebSocketConnectionClosedException:

--- a/neptune/internal/threads/hardware_metric_reporting_thread.py
+++ b/neptune/internal/threads/hardware_metric_reporting_thread.py
@@ -32,7 +32,7 @@ class HardwareMetricReportingThread(NeptuneThread):
 
     def run(self):
         try:
-            while not self.is_interrupted():
+            while self.should_continue_running():
                 before = time.time()
 
                 try:

--- a/neptune/internal/threads/neptune_thread.py
+++ b/neptune/internal/threads/neptune_thread.py
@@ -25,6 +25,8 @@ class NeptuneThread(threading.Thread):
         self._interrupted = threading.Event()
 
     def should_continue_running(self):
+        # TODO: remove this pylint exception once we stop supporting Python 2
+        # pylint: disable=no-member
         if utils.is_python_2():
             all_threads = threading.enumerate()
 

--- a/neptune/internal/threads/neptune_thread.py
+++ b/neptune/internal/threads/neptune_thread.py
@@ -31,7 +31,7 @@ class NeptuneThread(threading.Thread):
             all_threads = threading.enumerate()
 
             # pylint:disable=protected-access
-            main_thread_is_alive = any(t.__class__ is threading._MainThread for t in all_threads)
+            main_thread_is_alive = any(t.__class__ is threading._MainThread and t.is_alive() for t in all_threads)
         else:
             main_thread_is_alive = threading.main_thread().is_alive()
 

--- a/neptune/internal/threads/neptune_thread.py
+++ b/neptune/internal/threads/neptune_thread.py
@@ -15,7 +15,7 @@
 #
 import threading
 
-from neptune import utils
+import six
 
 
 class NeptuneThread(threading.Thread):
@@ -27,7 +27,7 @@ class NeptuneThread(threading.Thread):
     def should_continue_running(self):
         # TODO: remove this pylint exception once we stop supporting Python 2
         # pylint: disable=no-member
-        if utils.is_python_2():
+        if six.PY2:
             all_threads = threading.enumerate()
 
             # pylint:disable=protected-access

--- a/neptune/internal/threads/ping_thread.py
+++ b/neptune/internal/threads/ping_thread.py
@@ -32,7 +32,7 @@ class PingThread(NeptuneThread):
         self.__experiment = experiment
 
     def run(self):
-        while not self.is_interrupted():
+        while self.should_continue_running():
             try:
                 self.__backend.ping_experiment(self.__experiment)
             except HTTPUnprocessableEntity:

--- a/neptune/utils.py
+++ b/neptune/utils.py
@@ -266,7 +266,3 @@ def is_ipython():
         return ipython is not None
     except ImportError:
         return False
-
-
-def is_python_2():
-    return sys.version_info[0] == 2

--- a/neptune/utils.py
+++ b/neptune/utils.py
@@ -266,3 +266,7 @@ def is_ipython():
         return ipython is not None
     except ImportError:
         return False
+
+
+def is_python_2():
+    return sys.version_info[0] == 2


### PR DESCRIPTION
The goal here is to make the following script exit on Python 3.7 and later:
```python
import neptune
neptune.init()
neptune.create_experiment()
```

Before 3.7, when the main thread exited, a `join()` method was called on every daemonic thread. This changed and so we're now checking manually if the main thread still exists.