### PR TITLE
Fixes "neptune.init() throws exceptions with combination of ipython and offline-mode"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,7 @@ venv.bak/
 
 # Vim
 *.swp
+
+# VS Code
+.history
+.vscode

--- a/neptune/internal/backends/offline_backend.py
+++ b/neptune/internal/backends/offline_backend.py
@@ -131,14 +131,5 @@ class OfflineBackend(Backend):
 
 class NoopObject(object):
 
-    def __getattribute__(self, item):
-        return NoopObject()
-
-    def __call__(self, *args, **kwargs):
-        return NoopObject()
-
-    def __enter__(self):
-        return NoopObject()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+    def __getattr__(self, item):
+        return None

--- a/neptune/internal/backends/offline_backend.py
+++ b/neptune/internal/backends/offline_backend.py
@@ -132,4 +132,13 @@ class OfflineBackend(Backend):
 class NoopObject(object):
 
     def __getattr__(self, item):
-        return None
+        return self
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass

--- a/tests/neptune/internal/backends/test_noop_backend.py
+++ b/tests/neptune/internal/backends/test_noop_backend.py
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2019, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+
+from neptune.internal.backends.offline_backend import NoopObject
+
+class TestHostedNeptuneBackend(unittest.TestCase):
+
+    def test_builtin_fields_not_overriden(self):
+        objectUnderTest = NoopObject()
+        self.assertIsNotNone(objectUnderTest.__class__)

--- a/tests/neptune/internal/backends/test_noop_backend.py
+++ b/tests/neptune/internal/backends/test_noop_backend.py
@@ -22,4 +22,4 @@ class TestHostedNeptuneBackend(unittest.TestCase):
 
     def test_builtin_fields_not_overriden(self):
         objectUnderTest = NoopObject()
-        self.assertIsNotNone(objectUnderTest.__class__)
+        self.assertIsInstance(objectUnderTest.__class__, type)

--- a/tests/neptune/internal/backends/test_noop_object.py
+++ b/tests/neptune/internal/backends/test_noop_object.py
@@ -18,8 +18,21 @@ import unittest
 
 from neptune.internal.backends.offline_backend import NoopObject
 
-class TestHostedNeptuneBackend(unittest.TestCase):
+class TestHostedNeptuneObject(unittest.TestCase):
+
+    objectUnderTest = NoopObject()
+    some_value = 42
 
     def test_builtin_fields_not_overriden(self):
-        objectUnderTest = NoopObject()
-        self.assertIsInstance(objectUnderTest.__class__, type)
+        self.assertIsInstance(self.objectUnderTest.__class__, type)
+
+    def test_attributes_fall_back_on_getattr(self):
+        self.assertEqual(self.objectUnderTest.foo, self.objectUnderTest)
+        self.assertEqual(self.objectUnderTest.bar(self.some_value), self.objectUnderTest)
+
+    def test_noop_object_callable(self):
+        self.assertEqual(self.objectUnderTest(self.some_value), self.objectUnderTest)
+
+    def test_noop_object_context_manager(self):
+        with self.objectUnderTest as e:
+            e(42)

--- a/tests/neptune/internal/backends/test_noop_object.py
+++ b/tests/neptune/internal/backends/test_noop_object.py
@@ -20,19 +20,40 @@ from neptune.internal.backends.offline_backend import NoopObject
 
 class TestHostedNeptuneObject(unittest.TestCase):
 
+    # given
     objectUnderTest = NoopObject()
     some_value = 42
 
     def test_builtin_fields_not_overriden(self):
-        self.assertIsInstance(self.objectUnderTest.__class__, type)
+        #when
+        result = self.objectUnderTest.__class__
+
+        # then
+        self.assertIsInstance(result, type)
 
     def test_attributes_fall_back_on_getattr(self):
-        self.assertEqual(self.objectUnderTest.foo, self.objectUnderTest)
-        self.assertEqual(self.objectUnderTest.bar(self.some_value), self.objectUnderTest)
+        #when
+        attribute = self.objectUnderTest.foo
+
+        # and
+        method_call = self.objectUnderTest.bar(self.some_value)
+
+        # then
+        self.assertEqual(attribute, self.objectUnderTest)
+
+        # and
+        self.assertEqual(method_call, self.objectUnderTest)
 
     def test_noop_object_callable(self):
-        self.assertEqual(self.objectUnderTest(self.some_value), self.objectUnderTest)
+        # when
+        result = self.objectUnderTest(self.some_value)
+
+        # then
+        self.assertEqual(result, self.objectUnderTest)
 
     def test_noop_object_context_manager(self):
+        # when
         with self.objectUnderTest as e:
+
+            # then
             e(42)

--- a/tests/neptune/internal/backends/test_noop_object.py
+++ b/tests/neptune/internal/backends/test_noop_object.py
@@ -20,40 +20,36 @@ from neptune.internal.backends.offline_backend import NoopObject
 
 class TestHostedNeptuneObject(unittest.TestCase):
 
-    # given
-    objectUnderTest = NoopObject()
-    some_value = 42
-
     def test_builtin_fields_not_overriden(self):
-        #when
-        result = self.objectUnderTest.__class__
+        # given
+        objectUnderTest = NoopObject()
 
         # then
-        self.assertIsInstance(result, type)
+        self.assertIsInstance(objectUnderTest.__class__, type)
 
     def test_attributes_fall_back_on_getattr(self):
-        #when
-        attribute = self.objectUnderTest.foo
-
-        # and
-        method_call = self.objectUnderTest.bar(self.some_value)
+        # given
+        objectUnderTest = NoopObject()
+        some_value = 42
 
         # then
-        self.assertEqual(attribute, self.objectUnderTest)
-
-        # and
-        self.assertEqual(method_call, self.objectUnderTest)
+        self.assertEqual(objectUnderTest.foo, objectUnderTest)
+        self.assertEqual(objectUnderTest.bar(some_value), objectUnderTest)
 
     def test_noop_object_callable(self):
-        # when
-        result = self.objectUnderTest(self.some_value)
+        # given
+        objectUnderTest = NoopObject()
+        some_value = 42
 
         # then
-        self.assertEqual(result, self.objectUnderTest)
+        self.assertEqual(objectUnderTest(some_value), objectUnderTest)
 
     def test_noop_object_context_manager(self):
+        # given
+        objectUnderTest = NoopObject()
+
         # when
-        with self.objectUnderTest as e:
+        with objectUnderTest as e:
 
             # then
             e(42)


### PR DESCRIPTION
The fix was to replace `__getattribute__` with `__getattr__` in `NoopBackend` (difference explained [here](https://stackoverflow.com/questions/3278077/difference-between-getattr-vs-getattribute)).

Fixes https://neptune-labs.atlassian.net/browse/NPT-8209 , not sure how to link JIRA issues