### PR TITLE
POC: adjust HTTP client usage to bypass multiprocessing SSL issues

### DIFF
--- a/neptune/internal/channels/channels_values_sender.py
+++ b/neptune/internal/channels/channels_values_sender.py
@@ -15,6 +15,7 @@
 #
 import logging
 import threading
+import os
 import time
 from collections import namedtuple
 from itertools import groupby
@@ -26,6 +27,7 @@ from neptune.exceptions import NeptuneException
 from neptune.internal.channels.channels import ChannelIdWithValues, ChannelValue, \
     ChannelType, ChannelNamespace
 from neptune.internal.threads.neptune_thread import NeptuneThread
+
 
 _logger = logging.getLogger(__name__)
 
@@ -103,6 +105,7 @@ class ChannelsValuesSendingThread(NeptuneThread):
         self._experiment = experiment
         self._sleep_time = self._SLEEP_TIME
         self._values_batch = []
+        self._my_pid = os.getpid()
 
     def run(self):
         while self.should_continue_running() or not self._values_queue.empty():
@@ -152,6 +155,7 @@ class ChannelsValuesSendingThread(NeptuneThread):
             channels_with_values.append(ChannelIdWithValues(channel_id, channel_values))
 
         try:
+            print("Sending values from pid " + str(os.getpid()))
             # pylint:disable=protected-access
             self._experiment._send_channels_values(channels_with_values)
         except HTTPUnprocessableEntity as e:

--- a/neptune/internal/channels/channels_values_sender.py
+++ b/neptune/internal/channels/channels_values_sender.py
@@ -155,7 +155,6 @@ class ChannelsValuesSendingThread(NeptuneThread):
             channels_with_values.append(ChannelIdWithValues(channel_id, channel_values))
 
         try:
-            print("Sending values from pid " + str(os.getpid()))
             # pylint:disable=protected-access
             self._experiment._send_channels_values(channels_with_values)
         except HTTPUnprocessableEntity as e:

--- a/neptune/internal/threads/hardware_metric_reporting_thread.py
+++ b/neptune/internal/threads/hardware_metric_reporting_thread.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import logging
+import os
 import time
 
 from bravado.exception import HTTPError
@@ -29,10 +30,11 @@ class HardwareMetricReportingThread(NeptuneThread):
         super(HardwareMetricReportingThread, self).__init__(is_daemon=True)
         self.__metric_service = metric_service
         self.__metric_sending_interval_seconds = metric_sending_interval_seconds
+        self._owner_pid = os.getpid()
 
     def run(self):
         try:
-            while self.should_continue_running():
+            while self.should_continue_running() and os.getpid() == self._owner_pid:
                 before = time.time()
 
                 try:

--- a/neptune/internal/threads/ping_thread.py
+++ b/neptune/internal/threads/ping_thread.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import logging
+import os
 
 from bravado.exception import HTTPUnprocessableEntity
 
@@ -30,9 +31,10 @@ class PingThread(NeptuneThread):
 
         self.__backend = backend
         self.__experiment = experiment
+        self._owner_pid = os.getpid()
 
     def run(self):
-        while self.should_continue_running():
+        while self.should_continue_running() and os.getpid() == self._owner_pid:
             try:
                 self.__backend.ping_experiment(self.__experiment)
             except HTTPUnprocessableEntity:

--- a/neptune/projects.py
+++ b/neptune/projects.py
@@ -97,7 +97,7 @@ class Project(object):
                 | *Username* of the experiment owner (User who created experiment is an owner) like ``'josh'``
                   or list of owners like ``['frederic', 'josh']``.
                 | Matching any element of the list is sufficient to pass criterion.
-            tag (:obj:`str` or :obj:`list` of :obj:`str`, optional, default is ``None``):
+            tag (:obj:`str` or :obj:`list` of :obj:`st  r`, optional, default is ``None``):
                  | An experiment tag like ``'lightGBM'`` or list of tags like ``['pytorch', 'cycleLR']``.
                  | Only experiments that have all specified tags will match this criterion.
             min_running_time (:obj:`int`, optional, default is ``None``):


### PR DESCRIPTION
Following code causes SSL errors:

```
from neptune import HostedNeptuneBackend
import multiprocessing as mp
import time

class Logger(object):
    def __init__(self, project_name, experiment_id):
        self.worker = mp.Process(name="LoggingProcess",
                                 target=self._logging_func,
                                 kwargs={'project_name': project_name,
                                        'experiment_id': experiment_id})

    def start(self):
        self.worker.start()

    def stop(self, experiment):
        self.worker.terminate()
        experiment.stop()

    @staticmethod
    def _logging_func(project_name, experiment_id):
        session = Session(backend=HostedNeptuneBackend())
        project = session.get_project(project_qualified_name=project_name)
        experiment = project.get_experiments(id=experiment_id)[0]
        while True:
            #simulate logging
            experiment.send_metric("bar", 5)
            print("sent metric") # this is important
            time.sleep(0.1)



def training_proc(project_name, experiment_name):
    session = Session(backend=HostedNeptuneBackend())
    project = session.get_project(project_qualified_name=project_name)
    experiment = project.create_experiment(name=experiment_name)
    #experiment.stop() # when uncommented, there are no more SSL errors
    logger = Logger(project_name=project_name, experiment_id=experiment._id)
    logger.start()
    while True:
        #simulate training
        print("training") # this is important
        time.sleep(0.3)
    logger.stop(experiment)


training_proc("user/project", "test")
```

The error is caused by https://docs.python.org/2/library/ssl.html#multi-processing