### PR TITLE
pass verify when refreshing token

### DIFF
--- a/neptune/oauth.py
+++ b/neptune/oauth.py
@@ -51,7 +51,7 @@ class NeptuneAuth(AuthBase):
             self._refresh_token()
 
     def _refresh_token(self):
-        self.session.refresh_token(self.session.auto_refresh_url)
+        self.session.refresh_token(self.session.auto_refresh_url, verify=self.session.verify)
         if self.session.token is not None and self.session.token.get('access_token') is not None:
             decoded_json_token = jwt.decode(self.session.token.get('access_token'), verify=False)
             self.token_expires_at = decoded_json_token.get(u'exp')


### PR DESCRIPTION
Thanks for creating this great service!

I'm running Neptune behind a proxy (all certificates are self-signed) and getting the following error when creating an experiment: 

```
neptune.api_exceptions.SSLError: SSL certificate validation failed. Set NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE environment variable to accept self-signed certificates.
```

even though I did set the`NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE` env variable.

It looks as if the env variable is indeed picked up, but the `verify` flag isn't used everywhere. This PR fixes the issue.

I'm not sure what the workflow for this project is, so feel free to close this PR in case it doesn't fit with it.

/ Erik