### PR TITLE
Fixes errors caused by getitem access on offline backend.

### DIFF
--- a/neptune/internal/backends/offline_backend.py
+++ b/neptune/internal/backends/offline_backend.py
@@ -135,7 +135,10 @@ class OfflineBackend(Backend):
 
 class NoopObject(object):
 
-    def __getattr__(self, item):
+    def __getattr__(self, name):
+        return self
+
+    def __getitem__(self, key):
         return self
 
     def __call__(self, *args, **kwargs):

--- a/tests/neptune/internal/backends/test_noop_object.py
+++ b/tests/neptune/internal/backends/test_noop_object.py
@@ -36,6 +36,15 @@ class TestHostedNeptuneObject(unittest.TestCase):
         self.assertEqual(objectUnderTest.foo, objectUnderTest)
         self.assertEqual(objectUnderTest.bar(some_value), objectUnderTest)
 
+    def test_attributes_fall_back_on_getitem(self):
+        # given
+        objectUnderTest = NoopObject()
+        some_value = 42
+
+        # then
+        self.assertEqual(objectUnderTest['foo'], objectUnderTest)
+        self.assertEqual(objectUnderTest['bar'](some_value), objectUnderTest)
+
     def test_noop_object_callable(self):
         # given
         objectUnderTest = NoopObject()


### PR DESCRIPTION
Hi, thanks for the great work. This pull request is an attempt to fix potential problems in offline mode.

Without `__getitem__` access, changes like the following (L375) will break existing code when `offline_mode = True`:

https://github.com/PyTorchLightning/pytorch-lightning/pull/3462

I was trying to get initialization by experiment_id to work, and then I tried offline mode and got an error,

```
Traceback (most recent call last):
  File "./scripts/03_train_accel_interiornet_monocular.py", line 656, in <module>
    main()
  File "./scripts/03_train_accel_interiornet_monocular.py", line 625, in main
    experiment_id=latest_checkpoint_dict['log_version'],
  File "/opt/anaconda3/envs/fast/lib/python3.6/site-packages/pytorch_lightning/loggers/neptune.py", line 189, in __init__
    self._experiment = self._create_or_get_experiment()
  File "/opt/anaconda3/envs/fast/lib/python3.6/site-packages/pytorch_lightning/loggers/neptune.py", line 374, in _create_or_get_experiment
    exp = project.get_experiments(id=self.experiment_id)[0]
TypeError: 'NoopObject' object does not support indexing
```