### PR TITLE
Downgrade PyJWT do 1.7.1. Version 2.0.0+ is not currently compatible …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ py3nvml
 oauthlib>=2.1.0
 pandas
 Pillow>=1.1.6
-PyJWT
+PyJWT<2.0.0
 requests>=2.20.0
 requests-oauthlib>=1.0.0
 six>=1.12.0


### PR DESCRIPTION
…with neptune-client