### PR TITLE
Fix dataclasses and python version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ websocket-client>=0.35.0
 GitPython>=2.0.8
 packaging
 urllib3
-dataclasses>=0.6
+dataclasses>=0.6; python_version<"3.7"

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ def main():
         requirements = [r.strip() for r in f]
         setup(
             name='neptune-client',
+            python_requires='>=3.6.0',
             version=versioneer.get_version(),
             description='Neptune Client',
             author='neptune.ai',
@@ -24,7 +25,8 @@ def main():
             cmdclass=versioneer.get_cmdclass(),
             extras_require={
               "tensorflow-keras": ["neptune-tensorflow-keras"],
-              "sklearn": ["neptune-sklearn"]
+              "sklearn": ["neptune-sklearn"],
+              "lightgbm": ["neptune-lightgbm"]
             },
             entry_points={
                 'console_scripts': [
@@ -48,7 +50,6 @@ def main():
                 'Operating System :: Unix',
                 'Operating System :: Microsoft :: Windows',
                 'Programming Language :: Python',
-                'Programming Language :: Python :: 2',
                 'Programming Language :: Python :: 3',
                 'Topic :: Software Development :: Libraries :: Python Modules',
             ]


### PR DESCRIPTION
There is no dataclasses package for python>=3.7
since it's in standard library.