### PR TITLE
change: get all values from a given path, if possible

### DIFF
--- a/neptune/new/runs_table.py
+++ b/neptune/new/runs_table.py
@@ -39,16 +39,22 @@ class RunsTableEntry:
                 return attr.type
         raise ValueError("Could not find {} attribute".format(path))
 
+
     def get_attributes_from_path(self, path: str):
         path_attributes = {}
         prefix = path+'/'
         for attr in self._attributes:
             if attr.path.startswith(prefix):
                 key_name = attr.path[len(prefix):]
-                try:
-                    path_attributes[key_name] = self.get_attribute_value(attr.path)
-                except MetadataInconsistency as e:
-                    path_attributes[key_name] = e
+                if '/' in key_name:
+                    split = key_name.split('/')
+                    if split[0] not in path_attributes:
+                        path_attributes[split[0]] = self.get_attributes_from_path(prefix+split[0])
+                else:
+                    try:
+                        path_attributes[key_name] = self.get_attribute_value(attr.path)
+                    except MetadataInconsistency as e:
+                        path_attributes[key_name] = e
         return path_attributes
 
     def get_attribute_value(self, path: str):
@@ -57,7 +63,7 @@ class RunsTableEntry:
                 _type = attr.type
                 if _type == AttributeType.RUN_STATE:
                     return attr.properties.value
-                if _type == AttributeType.FLOAT or _type == AttributeType.STRING or _type == AttributeType.DATETIME:
+                if _type == AttributeType.INT or AttributeType.FLOAT or _type == AttributeType.STRING or _type == AttributeType.DATETIME:
                     return attr.properties.value
                 if _type == AttributeType.FLOAT_SERIES or _type == AttributeType.STRING_SERIES:
                     return attr.properties.last

--- a/neptune/new/runs_table.py
+++ b/neptune/new/runs_table.py
@@ -39,6 +39,18 @@ class RunsTableEntry:
                 return attr.type
         raise ValueError("Could not find {} attribute".format(path))
 
+    def get_attributes_from_path(self, path: str):
+        path_attributes = {}
+        prefix = path+'/'
+        for attr in self._attributes:
+            if attr.path.startswith(prefix):
+                key_name = attr.path[len(prefix):]
+                try:
+                    path_attributes[key_name] = self.get_attribute_value(attr.path)
+                except MetadataInconsistency as e:
+                    path_attributes[key_name] = e
+        return path_attributes
+
     def get_attribute_value(self, path: str):
         for attr in self._attributes:
             if attr.path == path:
@@ -96,6 +108,9 @@ class LeaderboardHandler:
 
     def get(self):
         return self._run.get_attribute_value(self._path)
+
+    def get_path(self):
+        return self._run.get_attributes_from_path(self._path)
 
     def download(self, destination: Optional[str]):
         attr_type = self._run.get_attribute_type(self._path)

--- a/neptune/new/runs_table.py
+++ b/neptune/new/runs_table.py
@@ -42,7 +42,7 @@ class RunsTableEntry:
 
     def get_attributes_from_path(self, path: str):
         path_attributes = {}
-        prefix = path+'/'
+        prefix = path  # +'/'
         for attr in self._attributes:
             if attr.path.startswith(prefix):
                 key_name = attr.path[len(prefix):]

--- a/neptune/new/runs_table.py
+++ b/neptune/new/runs_table.py
@@ -39,17 +39,20 @@ class RunsTableEntry:
                 return attr.type
         raise ValueError("Could not find {} attribute".format(path))
 
+    def _get_key_name(self, path, prefix):
+        key_name = path[len(prefix):]
+        return key_name[1:] if len(key_name) > 0 and key_name[0] is '/' else key_name
 
     def get_attributes_from_path(self, path: str):
         path_attributes = {}
-        prefix = path  # +'/'
+        prefix = path
         for attr in self._attributes:
             if attr.path.startswith(prefix):
-                key_name = attr.path[len(prefix):]
+                key_name = self._get_key_name(attr.path, prefix)
                 if '/' in key_name:
                     split = key_name.split('/')
                     if split[0] not in path_attributes:
-                        path_attributes[split[0]] = self.get_attributes_from_path(prefix+split[0])
+                        path_attributes[split[0]] = self.get_attributes_from_path(f'{prefix}/{split[0]}')
                 else:
                     try:
                         path_attributes[key_name] = self.get_attribute_value(attr.path)

--- a/neptune/new/runs_table.py
+++ b/neptune/new/runs_table.py
@@ -63,7 +63,7 @@ class RunsTableEntry:
                 _type = attr.type
                 if _type == AttributeType.RUN_STATE:
                     return attr.properties.value
-                if _type == AttributeType.INT or AttributeType.FLOAT or _type == AttributeType.STRING or _type == AttributeType.DATETIME:
+                if _type == AttributeType.INT or _type == AttributeType.FLOAT or _type == AttributeType.STRING or _type == AttributeType.DATETIME:
                     return attr.properties.value
                 if _type == AttributeType.FLOAT_SERIES or _type == AttributeType.STRING_SERIES:
                     return attr.properties.last

--- a/neptune/new/runs_table.py
+++ b/neptune/new/runs_table.py
@@ -66,7 +66,7 @@ class RunsTableEntry:
                 _type = attr.type
                 if _type == AttributeType.RUN_STATE:
                     return attr.properties.value
-                if _type == AttributeType.INT or _type == AttributeType.FLOAT or _type == AttributeType.STRING or _type == AttributeType.DATETIME:
+                if _type == AttributeType.BOOL or _type == AttributeType.INT or _type == AttributeType.FLOAT or _type == AttributeType.STRING or _type == AttributeType.DATETIME:
                     return attr.properties.value
                 if _type == AttributeType.FLOAT_SERIES or _type == AttributeType.STRING_SERIES:
                     return attr.properties.last


### PR DESCRIPTION
Dear Neptune-Team,

I didn't found the possibility to get back a path (like 'params') as a `dict` from a certain run.
This might be helpful if you initialize a model using the params as a `dict` and you don't know each param of each model to construct.
So I added two functions.

I would really be happy if you either could accept my pull request or tell me how I can achieve this in another way.
(unfortunately, I was not able to get your unit tests running, so I skipped writing a test 😕 

Thank you very much.