### PR TITLE
fix stopping run without sending data

### DIFF
--- a/neptune/new/internal/threading/daemon.py
+++ b/neptune/new/internal/threading/daemon.py
@@ -42,9 +42,11 @@ class Daemon(threading.Thread):
     def run(self):
         self._is_running = True
         try:
-            while not self._interrupted:
+            while True:
                 self.work()
-                if self._sleep_time > 0 and not self._interrupted:
+                if self._interrupted:
+                    break
+                if self._sleep_time > 0:
                     self._event.wait(timeout=self._sleep_time)
                     self._event.clear()
         finally:


### PR DESCRIPTION
change Daemon.run so that Daemon.work gets at least one chance to run when interrupt is called