### PR TITLE
Reassigning dict to Namespace

### DIFF
--- a/neptune/new/attributes/namespace.py
+++ b/neptune/new/attributes/namespace.py
@@ -61,13 +61,7 @@ class Namespace(Attribute, MutableMapping):
             value = NamespaceVal(value)
 
         for k, v in value.value.items():
-            abs_path = f"{self._str_path}/{k}"
-            attr = self._run.get_attribute(abs_path)
-
-            if attr:
-                attr.assign(v, wait)
-            else:
-                self._run.define(abs_path, v)
+            self._run[f"{self._str_path}/{k}"].assign(v, wait)
 
     def _collect_atom_values(self, attribute_dict) -> dict:
         result = {}

--- a/neptune/new/attributes/namespace.py
+++ b/neptune/new/attributes/namespace.py
@@ -61,10 +61,13 @@ class Namespace(Attribute, MutableMapping):
             value = NamespaceVal(value)
 
         for k, v in value.value.items():
-            if k in self:
-                self[k].assign(v, wait)
+            abs_path = f"{self._str_path}/{k}"
+            attr = self._run.get_attribute(abs_path)
+
+            if attr:
+                attr.assign(v, wait)
             else:
-                self._run.define(f"{self._str_path}/{k}", v)
+                self._run.define(abs_path, v)
 
     def _collect_atom_values(self, attribute_dict) -> dict:
         result = {}


### PR DESCRIPTION
Following samples should be consistent:
1.
```
run['best'] = {'trials/0/a': 1}
run['best'] = {'trials/0/a': 2}
```

2.
```
run['best/trials/0/a'] = 1
run['best'] = {'trials/0/a': 2}
```

3.
```
run['best/trials/0/a'] = 1
run['best/trials/0/a'] = 2
```

Currently first one raises an `MetadataInconsistency` exception in compare of successful execution of 2 followings.