### PR TITLE
return path from requested prefix instead of root when fetching namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## neptune-client 0.9.20 [UNRELEASED]
+## neptune-client 0.10.0 [UNRELEASED]
+
+### Breaking changes
+- Return path from requested prefix instead of root when fetching namespace ([#XXX](https://github.com/neptune-ai/neptune-client/pull/XXX))
 
 ### Features
 - Heuristics to help users find out they're writing legacy code with new client API or vice versa ([#607](https://github.com/neptune-ai/neptune-client/pull/607))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## neptune-client 0.10.0 [UNRELEASED]
 
 ### Breaking changes
-- Return path from requested prefix instead of root when fetching namespace ([#XXX](https://github.com/neptune-ai/neptune-client/pull/XXX))
+- Return path from requested prefix instead of root when fetching namespace ([#609](https://github.com/neptune-ai/neptune-client/pull/609))
 
 ### Features
 - Heuristics to help users find out they're writing legacy code with new client API or vice versa ([#607](https://github.com/neptune-ai/neptune-client/pull/607))

--- a/neptune/new/attributes/namespace.py
+++ b/neptune/new/attributes/namespace.py
@@ -17,9 +17,10 @@ from collections.abc import MutableMapping
 from typing import Any, Dict, TYPE_CHECKING, Iterator, List, Mapping, Union
 
 from neptune.new.attributes.attribute import Attribute
+from neptune.new.internal.run_structure import RunStructure
 from neptune.new.internal.utils.generic_attribute_mapper import atomic_attribute_types_map, NoValue
+from neptune.new.internal.utils.paths import parse_path, path_to_str
 from neptune.new.types.namespace import Namespace as NamespaceVal
-from neptune.new.internal.utils.paths import path_to_str
 
 if TYPE_CHECKING:
     from neptune.new.run import Run
@@ -75,8 +76,6 @@ class Namespace(Attribute, MutableMapping):
 
     def fetch(self) -> dict:
         attributes = self._backend.fetch_atom_attribute_values(self._run_uuid, self._path)
-        from neptune.new.internal.run_structure import RunStructure
-        from neptune.new.internal.utils.paths import parse_path
         run_struct = RunStructure()
         prefix_len = len(self._path)
         for attr_name, attr_type, attr_value in attributes:

--- a/neptune/new/attributes/namespace.py
+++ b/neptune/new/attributes/namespace.py
@@ -21,7 +21,6 @@ from neptune.new.internal.utils.generic_attribute_mapper import atomic_attribute
 from neptune.new.types.namespace import Namespace as NamespaceVal
 from neptune.new.internal.utils.paths import path_to_str
 
-
 if TYPE_CHECKING:
     from neptune.new.run import Run
 
@@ -75,8 +74,14 @@ class Namespace(Attribute, MutableMapping):
         return result
 
     def fetch(self) -> dict:
-        namespace_values = self._backend.fetch_atom_attribute_values(self._run_uuid, self._path)
-        return self._collect_atom_values(namespace_values)
+        attributes = self._backend.fetch_atom_attribute_values(self._run_uuid, self._path)
+        from neptune.new.internal.run_structure import RunStructure
+        from neptune.new.internal.utils.paths import parse_path
+        run_struct = RunStructure()
+        prefix_len = len(self._path)
+        for attr_name, attr_type, attr_value in attributes:
+            run_struct.set(parse_path(attr_name)[prefix_len:], (attr_type, attr_value))
+        return self._collect_atom_values(run_struct.get_structure())
 
 
 class NamespaceBuilder:

--- a/neptune/new/internal/backends/hosted_neptune_backend.py
+++ b/neptune/new/internal/backends/hosted_neptune_backend.py
@@ -27,7 +27,6 @@ from bravado.exception import HTTPNotFound, HTTPUnprocessableEntity
 from bravado.requests_client import RequestsClient
 from packaging import version
 
-from neptune.new.attributes.namespace import Namespace
 from neptune.new.envs import NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE
 from neptune.new.exceptions import (
     ClientHttpError,
@@ -90,10 +89,9 @@ from neptune.new.internal.operation import (
     UploadFileContent,
     UploadFileSet,
 )
-from neptune.new.internal.run_structure import RunStructure
 from neptune.new.internal.utils import verify_type, base64_decode
 from neptune.new.internal.utils.generic_attribute_mapper import map_attribute_result_to_value
-from neptune.new.internal.utils.paths import path_to_str, parse_path
+from neptune.new.internal.utils.paths import path_to_str
 from neptune.new.internal.websockets.websockets_factory import WebsocketsFactory
 from neptune.new.types.atoms import GitRef
 from neptune.new.version import version as neptune_client_version

--- a/neptune/new/internal/backends/neptune_backend.py
+++ b/neptune/new/internal/backends/neptune_backend.py
@@ -14,14 +14,14 @@
 # limitations under the License.
 #
 import abc
-import typing
 import uuid
-from typing import List, Optional
+from typing import Any, List, Tuple, Optional
 
 from neptune.new.exceptions import NeptuneException
 from neptune.new.internal.backends.api_model import (
     ApiRun,
     Attribute,
+    AttributeType,
     BoolAttribute,
     DatetimeAttribute,
     FileAttribute,
@@ -153,5 +153,5 @@ class NeptuneBackend:
         pass
 
     @abc.abstractmethod
-    def fetch_atom_attribute_values(self, run_uuid: uuid.UUID, path: List[str]) -> typing.Union[typing.Mapping, dict]:
+    def fetch_atom_attribute_values(self, run_uuid: uuid.UUID, path: List[str]) -> List[Tuple[str, AttributeType, Any]]:
         pass

--- a/neptune/new/internal/run_structure.py
+++ b/neptune/new/internal/run_structure.py
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import typing
-from typing import Optional, List, TypeVar, Generic, Callable
+from typing import Optional, List, TypeVar, Generic, Callable, Union
 
 from neptune.new.exceptions import MetadataInconsistency
 from neptune.new.internal.utils.paths import path_to_str
@@ -29,7 +28,7 @@ def _default_node_factory(path):
 
 
 class RunStructure(Generic[T, Node]):
-    def __init__(self, node_factory: typing.Optional[Callable[[List[str]], Node]] = None):
+    def __init__(self, node_factory: Optional[Callable[[List[str]], Node]] = None):
         if node_factory is None:
             node_factory = _default_node_factory
 
@@ -40,7 +39,7 @@ class RunStructure(Generic[T, Node]):
     def get_structure(self) -> Node:
         return self._structure
 
-    def get(self, path: List[str]) -> Optional[T]:
+    def get(self, path: List[str]) -> Union[T, Node, None]:
         ref = self._structure
 
         for index, part in enumerate(path):

--- a/tests/neptune/new/test_handler.py
+++ b/tests/neptune/new/test_handler.py
@@ -414,7 +414,8 @@ class TestHandler(unittest.TestCase):
         exp['params/sub-namespace/int'] = 42
         exp['params/sub-namespace/string'] = 'Some text'
 
-        print(type(exp['params/sub-namespace'].fetch))
+        # pylint: disable=assignment-from-no-return
+        # that's a false positive, pylint looks at Handler.fetch()
         params_dict = exp['params/sub-namespace'].fetch()
         self.assertDictEqual(params_dict, {
             'int': 42,

--- a/tests/neptune/new/test_handler.py
+++ b/tests/neptune/new/test_handler.py
@@ -403,6 +403,24 @@ class TestHandler(unittest.TestCase):
             }
         })
 
+    def test_fetch_dict_with_path(self):
+        now = datetime.now()
+
+        exp = init(mode='debug', flush_period=0.5)
+        exp['params/int'] = 1
+        exp['params/float'] = 3.14
+        exp['params/bool'] = True
+        exp['params/datetime'] = now
+        exp['params/sub-namespace/int'] = 42
+        exp['params/sub-namespace/string'] = 'Some text'
+
+        print(type(exp['params/sub-namespace'].fetch))
+        params_dict = exp['params/sub-namespace'].fetch()
+        self.assertDictEqual(params_dict, {
+            'int': 42,
+            'string': 'Some text',
+        })
+
     @dataclass
     class FloatLike:
 


### PR DESCRIPTION
ref. https://neptune-labs.atlassian.net/browse/NPT-10417

before:
```
import neptune.new as neptunerun = neptune.init()
run['model/params'] = {'a': 3}
run.wait()
params run['model/params'].fetch() == {'model': {'params': {'a': 3}}}
```

after:
```
import neptune.new as neptunerun = neptune.init()
run['model/params'] = {'a': 3}
run.wait()
params run['model/params'].fetch() == {'a': 3}
```

Also refactored `fetch_atom_attribute_values` to make it more unit-testable.
