### PR TITLE
Applied project lookup new behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Features
 - Heuristics to help users find out they're writing legacy code with new client API or vice versa ([#607](https://github.com/neptune-ai/neptune-client/pull/607))
-- Lookup for projects without workspace specification and listing user projects and workspaces ([#615]()https://github.com/neptune-ai/neptune-client/pull/615)
+- Lookup for projects without workspace specification and listing user projects and workspaces ([#615](https://github.com/neptune-ai/neptune-client/pull/615))
 
 ## neptune-client 0.9.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 - Heuristics to help users find out they're writing legacy code with new client API or vice versa ([#607](https://github.com/neptune-ai/neptune-client/pull/607))
+- Lookup for projects without workspace specification and listing user projects and workspaces ([#615]()https://github.com/neptune-ai/neptune-client/pull/615)
 
 ## neptune-client 0.9.19
 

--- a/neptune/new/exceptions.py
+++ b/neptune/new/exceptions.py
@@ -155,8 +155,12 @@ You can check all of your projects on the Projects page:
         )
 
         self.inputs = {
-            'available_projects_message': available_projects_message.format(projects=projects_formated_list) if available_projects else '',
-            'available_workspaces_message': available_workspaces_message.format(workspaces_urls=workspaces_formated_list) if available_workspaces else '',
+            'available_projects_message': available_projects_message.format(
+                projects=projects_formated_list
+            ) if available_projects else '',
+            'available_workspaces_message': available_workspaces_message.format(
+                workspaces_urls=workspaces_formated_list
+            ) if available_workspaces else '',
             **STYLES,
             **kwargs
         }
@@ -712,5 +716,6 @@ class PlotlyIncompatibilityException(Exception):
             "Unable to convert plotly figure to matplotlib format. "
             "Your matplotlib ({}) and plotlib ({}) versions are not compatible. "
             "See https://stackoverflow.com/q/63120058 for details. "
-            "Downgrade matplotlib to version 3.2 or use as_image to log static chart."
-                .format(matplotlib_version, plotly_version))
+            "Downgrade matplotlib to version 3.2 or use as_image to log static chart.".format(
+                matplotlib_version,
+                plotly_version))

--- a/neptune/new/exceptions.py
+++ b/neptune/new/exceptions.py
@@ -187,38 +187,25 @@ You may also want to check the following docs pages:
                          project=project_id)
 
 
-class RunNotFound(NeptuneException):
-
-    def __init__(self, run_id: str) -> None:
-        super().__init__("Run {} not found.".format(run_id))
-
-
-class RunUUIDNotFound(NeptuneException):
-    def __init__(self, run_uuid: uuid.UUID):
-        super().__init__("Run with UUID {} not found. Could be deleted.".format(run_uuid))
-
-
-class InactiveRunException(NeptuneException):
-    def __init__(self, short_id: str):
+class ProjectNameCollision(ExceptionWithProjectsWorkspacesListing):
+    def __init__(self,
+                 project_id: str,
+                 available_projects: List[Project] = ()):
         message = """
 {h1}
-----InactiveRunException----------------------------------------
+----NeptuneProjectNameCollisionException------------------------------------
 {end}
-It seems you are trying to log (or fetch) metadata to a run that was stopped ({short_id}).
-What should I do?
-    - Resume the run to continue logging to it:
-    https://docs.neptune.ai/how-to-guides/neptune-api/resume-run#how-to-resume-run
-    - Don't invoke `stop()` on a run that you want to access. If you want to stop monitoring only, 
-    you can resume a run in read-only mode:
-    https://docs.neptune.ai/you-should-know/connection-modes#read-only
+Cannot resolve project {fail}"{project}"{end}.
+{available_projects_message}
 You may also want to check the following docs pages:
-    - https://docs.neptune.ai/api-reference/run#stop
-    - https://docs.neptune.ai/how-to-guides/neptune-api/resume-run#how-to-resume-run
-    - https://docs.neptune.ai/you-should-know/connection-modes
+    - https://docs.neptune.ai/administration/workspace-project-and-user-management/projects
+    - https://docs.neptune.ai/getting-started/hello-world#project
+
 {correct}Need help?{end}-> https://docs.neptune.ai/getting-started/getting-help
 """
-        inputs = dict(list({'short_id': short_id}.items()) + list(STYLES.items()))
-        super().__init__(message.format(**inputs))
+        super().__init__(message=message,
+                         available_projects=available_projects,
+                         project=project_id)
 
 
 class NeptuneMissingProjectNameException(ExceptionWithProjectsWorkspacesListing):
@@ -265,38 +252,38 @@ You may also want to check the following docs pages:
                          env_project=envs.PROJECT_ENV_NAME)
 
 
-class NeptuneIncorrectProjectNameException(ExceptionWithProjectsWorkspacesListing):
-    def __init__(self,
-                 project: str,
-                 available_projects: List[Project] = (),
-                 available_workspaces: List[Workspace] = ()):
+class RunNotFound(NeptuneException):
+
+    def __init__(self, run_id: str) -> None:
+        super().__init__("Run {} not found.".format(run_id))
+
+
+class RunUUIDNotFound(NeptuneException):
+    def __init__(self, run_uuid: uuid.UUID):
+        super().__init__("Run with UUID {} not found. Could be deleted.".format(run_uuid))
+
+
+class InactiveRunException(NeptuneException):
+    def __init__(self, short_id: str):
         message = """
 {h1}
-----NeptuneIncorrectProjectNameException------------------------------------
+----InactiveRunException----------------------------------------
 {end}
-Project name {fail}"{project}"{end} you specified seems to be incorrect.
-{available_projects_message}{available_workspaces_message}
-The correct project name should look like this {correct}WORKSPACE/PROJECT_NAME{end}.
-It has two parts:
-    - {correct}WORKSPACE{end}: which can be your username or your organization name
-    - {correct}PROJECT_NAME{end}: which is the actual project name you chose 
-
-For example, a project {correct}neptune-ai/credit-default-prediction{end} parts are:
-    - {correct}neptune-ai{end}: {underline}WORKSPACE{end} our company organization name
-    - {correct}credit-default-prediction{end}: {underline}PROJECT_NAME{end} a project name
-
-The URL to this project looks like this: https://app.neptune.ai/neptune-ai/credit-default-prediction
-
+It seems you are trying to log (or fetch) metadata to a run that was stopped ({short_id}).
+What should I do?
+    - Resume the run to continue logging to it:
+    https://docs.neptune.ai/how-to-guides/neptune-api/resume-run#how-to-resume-run
+    - Don't invoke `stop()` on a run that you want to access. If you want to stop monitoring only, 
+    you can resume a run in read-only mode:
+    https://docs.neptune.ai/you-should-know/connection-modes#read-only
 You may also want to check the following docs pages:
-    - https://docs.neptune.ai/administration/workspace-project-and-user-management/projects
-    - https://docs.neptune.ai/getting-started/hello-world#project
-
+    - https://docs.neptune.ai/api-reference/run#stop
+    - https://docs.neptune.ai/how-to-guides/neptune-api/resume-run#how-to-resume-run
+    - https://docs.neptune.ai/you-should-know/connection-modes
 {correct}Need help?{end}-> https://docs.neptune.ai/getting-started/getting-help
 """
-        super().__init__(message=message,
-                         available_projects=available_projects,
-                         available_workspaces=available_workspaces,
-                         project=project)
+        inputs = dict(list({'short_id': short_id}.items()) + list(STYLES.items()))
+        super().__init__(message.format(**inputs))
 
 
 class NeptuneMissingApiTokenException(NeptuneException):

--- a/neptune/new/internal/backends/hosted_neptune_backend.py
+++ b/neptune/new/internal/backends/hosted_neptune_backend.py
@@ -29,6 +29,7 @@ from packaging import version
 
 from neptune.new.attributes.namespace import Namespace
 from neptune.new.envs import NEPTUNE_ALLOW_SELF_SIGNED_CERTIFICATE
+from neptune.patterns import PROJECT_QUALIFIED_NAME_PATTERN
 from neptune.new.exceptions import (
     ClientHttpError,
     FetchAttributeNotFoundException,
@@ -39,8 +40,8 @@ from neptune.new.exceptions import (
     NeptuneException,
     NeptuneLegacyProjectException,
     ProjectNotFound,
+    ProjectNameCollision,
     NeptuneStorageLimitException,
-    NeptuneIncorrectProjectNameException,
     UnsupportedClientVersion,
 )
 from neptune.new.internal.backends.api_model import (
@@ -178,27 +179,27 @@ class HostedNeptuneBackend(NeptuneBackend):
     def get_project(self, project_id: str) -> Project:
         verify_type("project_id", project_id, str)
 
+        project_spec = re.search(PROJECT_QUALIFIED_NAME_PATTERN, project_id)
+        workspace, name = project_spec['workspace'], project_spec['project']
+
         try:
-            project_spec = re.search(PROJECT_QUALIFIED_NAME_PATTERN, name)
-            if not project_spec['workspace']:
-                available_projects = backend.get_available_projects(search_term=project_spec['project'])
+            if not workspace:
+                available_projects = list(filter(lambda p: p.name == name, self.get_available_projects(search_term=name)))
 
-                if len(available_projects) == 1 and available_projects[0].name == project_spec['project']:
-                    name = f'{available_projects[0].workspace}/{available_projects[0].name}'
+                if len(available_projects) == 1:
+                    project = available_projects[0]
+                    project_id = f'{project.workspace}/{project.name}'
+                elif len(available_projects) > 1:
+                    raise ProjectNameCollision(
+                        project_id=project_id,
+                        available_projects=available_projects
+                    )
                 else:
-                    available_workspaces = backend.get_available_workspaces()
-                    raise NeptuneIncorrectProjectNameException(project=name,
-                                                               available_workspaces=available_workspaces,
-                                                               available_projects=available_projects)
-            else:
-                available_workspaces: List[Workspace] = backend.get_available_workspaces()
-
-                if project_spec['workspace'] not in {workspace.name for workspace in available_workspaces}:
-                    available_projects = backend.get_available_projects()
-
-                    raise NeptuneIncorrectProjectNameException(project=name,
-                                                               available_workspaces=available_workspaces,
-                                                               available_projects=available_projects)
+                    raise ProjectNotFound(
+                        project_id=project_id,
+                        available_projects=self.get_available_projects(),
+                        available_workspaces=self.get_available_workspaces()
+                    )
 
             response = self.backend_client.api.getProject(
                 projectIdentifier=project_id,
@@ -213,11 +214,9 @@ class HostedNeptuneBackend(NeptuneBackend):
                 raise NeptuneLegacyProjectException(project_id)
             return Project(uuid.UUID(project.id), project.name, project.organizationName)
         except HTTPNotFound:
-            available_workspaces = self.get_available_workspaces()
-
             raise ProjectNotFound(project_id,
-                                  available_projects=available_projects,
-                                  available_workspaces=available_workspaces)
+                                  available_projects=self.get_available_projects(workspace_id=workspace),
+                                  available_workspaces=list() if workspace else self.get_available_workspaces())
 
     @with_api_exceptions_handler
     def get_available_projects(self,

--- a/neptune/new/internal/backends/hosted_neptune_backend.py
+++ b/neptune/new/internal/backends/hosted_neptune_backend.py
@@ -184,7 +184,8 @@ class HostedNeptuneBackend(NeptuneBackend):
 
         try:
             if not workspace:
-                available_projects = list(filter(lambda p: p.name == name, self.get_available_projects(search_term=name)))
+                available_projects = list(filter(lambda p: p.name == name,
+                                                 self.get_available_projects(search_term=name)))
 
                 if len(available_projects) == 1:
                     project = available_projects[0]

--- a/neptune/new/internal/backends/neptune_backend_mock.py
+++ b/neptune/new/internal/backends/neptune_backend_mock.py
@@ -103,16 +103,16 @@ class NeptuneBackendMock(NeptuneBackend):
         return "OFFLINE"
 
     def get_project(self, project_id: str) -> Project:
-        return Project(uuid.uuid4(), "sandbox", "workspace")
+        return Project(uuid.uuid4(), "project-placeholder", "offline")
 
     def get_available_projects(self,
                                workspace_id: Optional[str] = None,
                                search_term: Optional[str] = None
                                ) -> List[Project]:
-        return [Project(uuid.uuid4(), "sandbox", "workspace")]
+        return [Project(uuid.uuid4(), "project-placeholder", "offline")]
 
     def get_available_workspaces(self) -> List[Workspace]:
-        return [Workspace(uuid.uuid4(), "workspace")]
+        return [Workspace(uuid.uuid4(), "offline")]
 
     def create_run(self,
                    project_uuid: uuid.UUID,

--- a/neptune/new/internal/backends/project_lookup.py
+++ b/neptune/new/internal/backends/project_lookup.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2021, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging
+import os
+import re
+from typing import Optional, List
+
+from neptune.patterns import PROJECT_QUALIFIED_NAME_PATTERN
+
+from neptune.new.envs import PROJECT_ENV_NAME
+from neptune.new.exceptions import NeptuneMissingProjectNameException
+from neptune.new.internal.backends.neptune_backend import NeptuneBackend
+from neptune.new.internal.utils import verify_type
+from neptune.new.project import Project
+from neptune.new.version import version as parsed_version
+
+__version__ = str(parsed_version)
+
+_logger = logging.getLogger(__name__)
+
+
+def project_lookup(backend: NeptuneBackend, name: Optional[str] = None) -> Project:
+    verify_type("name", name, (str, type(None)))
+
+    if not name:
+        name = os.getenv(PROJECT_ENV_NAME)
+    if not name:
+        available_workspaces = backend.get_available_workspaces()
+        available_projects = backend.get_available_projects()
+
+        raise NeptuneMissingProjectNameException(available_workspaces=available_workspaces,
+                                                 available_projects=available_projects)
+
+    return backend.get_project(name)

--- a/neptune/new/internal/backends/project_name_lookup.py
+++ b/neptune/new/internal/backends/project_name_lookup.py
@@ -15,10 +15,7 @@
 #
 import logging
 import os
-import re
-from typing import Optional, List
-
-from neptune.patterns import PROJECT_QUALIFIED_NAME_PATTERN
+from typing import Optional
 
 from neptune.new.envs import PROJECT_ENV_NAME
 from neptune.new.exceptions import NeptuneMissingProjectNameException
@@ -32,7 +29,7 @@ __version__ = str(parsed_version)
 _logger = logging.getLogger(__name__)
 
 
-def project_lookup(backend: NeptuneBackend, name: Optional[str] = None) -> Project:
+def project_name_lookup(backend: NeptuneBackend, name: Optional[str] = None) -> Project:
     verify_type("name", name, (str, type(None)))
 
     if not name:

--- a/neptune/new/internal/get_project_impl.py
+++ b/neptune/new/internal/get_project_impl.py
@@ -17,7 +17,7 @@ import logging
 from typing import Optional
 
 from neptune.new.internal.backends.hosted_neptune_backend import HostedNeptuneBackend
-from neptune.new.internal.backends.project_lookup import project_lookup
+from neptune.new.internal.backends.project_name_lookup import project_name_lookup
 from neptune.new.internal.credentials import Credentials
 from neptune.new.internal.utils import verify_type
 from neptune.new.project import Project
@@ -62,6 +62,6 @@ def get_project(name: Optional[str] = None, api_token: Optional[str] = None) -> 
     verify_type("api_token", api_token, (str, type(None)))
 
     backend = HostedNeptuneBackend(Credentials(api_token=api_token))
-    project_obj = project_lookup(backend, name)
+    project_obj = project_name_lookup(backend, name)
 
     return Project(project_obj.uuid, backend)

--- a/neptune/new/internal/get_project_impl.py
+++ b/neptune/new/internal/get_project_impl.py
@@ -14,15 +14,10 @@
 # limitations under the License.
 #
 import logging
-import os
-import re
 from typing import Optional
 
-from neptune.patterns import PROJECT_QUALIFIED_NAME_PATTERN
-
-from neptune.new.envs import PROJECT_ENV_NAME
-from neptune.new.exceptions import NeptuneIncorrectProjectNameException, NeptuneMissingProjectNameException
 from neptune.new.internal.backends.hosted_neptune_backend import HostedNeptuneBackend
+from neptune.new.internal.backends.project_lookup import project_lookup
 from neptune.new.internal.credentials import Credentials
 from neptune.new.internal.utils import verify_type
 from neptune.new.project import Project
@@ -66,15 +61,7 @@ def get_project(name: Optional[str] = None, api_token: Optional[str] = None) -> 
     verify_type("name", name, (str, type(None)))
     verify_type("api_token", api_token, (str, type(None)))
 
-    if not name:
-        name = os.getenv(PROJECT_ENV_NAME)
-    if not name:
-        raise NeptuneMissingProjectNameException()
-    if not re.match(PROJECT_QUALIFIED_NAME_PATTERN, name):
-        raise NeptuneIncorrectProjectNameException(name)
-
     backend = HostedNeptuneBackend(Credentials(api_token=api_token))
-
-    project_obj = backend.get_project(name)
+    project_obj = project_lookup(backend, name)
 
     return Project(project_obj.uuid, backend)

--- a/neptune/new/internal/init_impl.py
+++ b/neptune/new/internal/init_impl.py
@@ -255,8 +255,6 @@ def init(project: Optional[str] = None,
     else:
         raise ValueError(f'mode should be one of {[m for m in RunMode]}')
 
-    # return backend
-
     if mode == RunMode.OFFLINE or mode == RunMode.DEBUG:
         project = 'offline/project-placeholder'
 

--- a/neptune/new/internal/init_impl.py
+++ b/neptune/new/internal/init_impl.py
@@ -37,6 +37,7 @@ from neptune.new.exceptions import (NeedExistingRunForReadOnlyMode, NeptuneIncor
                                     NeptuneMissingProjectNameException, NeptuneRunResumeAndCustomIdCollision)
 from neptune.new.internal.backends.hosted_neptune_backend import HostedNeptuneBackend
 from neptune.new.internal.backends.neptune_backend import NeptuneBackend
+from neptune.new.internal.backends.project_lookup import project_lookup
 from neptune.new.internal.backends.neptune_backend_mock import NeptuneBackendMock
 from neptune.new.internal.backends.offline_neptune_backend import OfflineNeptuneBackend
 from neptune.new.internal.backgroud_job_list import BackgroundJobList
@@ -244,14 +245,9 @@ def init(project: Optional[str] = None,
 
     if mode == RunMode.OFFLINE or mode == RunMode.DEBUG:
         project = 'offline/project-placeholder'
-    elif not project:
-        project = os.getenv(PROJECT_ENV_NAME)
-        if not project:
-            raise NeptuneMissingProjectNameException()
-    if not re.match(PROJECT_QUALIFIED_NAME_PATTERN, project):
-        raise NeptuneIncorrectProjectNameException(project)
 
-    project_obj = backend.get_project(project)
+    project_obj = project_lookup(backend, project)
+
     if run:
         api_run = backend.get_run(project + '/' + run)
     else:

--- a/neptune/new/internal/init_impl.py
+++ b/neptune/new/internal/init_impl.py
@@ -16,7 +16,6 @@
 
 import logging
 import os
-import re
 import uuid
 from datetime import datetime
 from enum import Enum
@@ -32,12 +31,11 @@ from neptune.new.constants import (
     NEPTUNE_RUNS_DIRECTORY,
     OFFLINE_DIRECTORY,
 )
-from neptune.new.envs import CUSTOM_RUN_ID_ENV_NAME, NEPTUNE_NOTEBOOK_ID, NEPTUNE_NOTEBOOK_PATH, PROJECT_ENV_NAME
-from neptune.new.exceptions import (NeedExistingRunForReadOnlyMode, NeptuneIncorrectProjectNameException,
-                                    NeptuneMissingProjectNameException, NeptuneRunResumeAndCustomIdCollision)
+from neptune.new.envs import CUSTOM_RUN_ID_ENV_NAME, NEPTUNE_NOTEBOOK_ID, NEPTUNE_NOTEBOOK_PATH
+from neptune.new.exceptions import (NeedExistingRunForReadOnlyMode, NeptuneRunResumeAndCustomIdCollision)
 from neptune.new.internal.backends.hosted_neptune_backend import HostedNeptuneBackend
 from neptune.new.internal.backends.neptune_backend import NeptuneBackend
-from neptune.new.internal.backends.project_lookup import project_lookup
+from neptune.new.internal.backends.project_name_lookup import project_name_lookup
 from neptune.new.internal.backends.neptune_backend_mock import NeptuneBackendMock
 from neptune.new.internal.backends.offline_neptune_backend import OfflineNeptuneBackend
 from neptune.new.internal.backgroud_job_list import BackgroundJobList
@@ -65,7 +63,6 @@ from neptune.new.internal.websockets.websocket_signals_background_job import Web
 from neptune.new.run import Run
 from neptune.new.types.series.string_series import StringSeries
 from neptune.new.version import version as parsed_version
-from neptune.patterns import PROJECT_QUALIFIED_NAME_PATTERN
 
 __version__ = str(parsed_version)
 
@@ -243,10 +240,12 @@ def init(project: Optional[str] = None,
     else:
         raise ValueError(f'mode should be one of {[m for m in RunMode]}')
 
+    # return backend
+
     if mode == RunMode.OFFLINE or mode == RunMode.DEBUG:
         project = 'offline/project-placeholder'
 
-    project_obj = project_lookup(backend, project)
+    project_obj = project_name_lookup(backend, project)
 
     if run:
         api_run = backend.get_run(project + '/' + run)

--- a/neptune/new/internal/init_impl.py
+++ b/neptune/new/internal/init_impl.py
@@ -259,6 +259,7 @@ def init(project: Optional[str] = None,
         project = 'offline/project-placeholder'
 
     project_obj = project_name_lookup(backend, project)
+    project = f'{project_obj.workspace}/{project_obj.name}'
 
     if run:
         api_run = backend.get_run(project + '/' + run)

--- a/neptune/patterns.py
+++ b/neptune/patterns.py
@@ -15,4 +15,4 @@
 #
 
 
-PROJECT_QUALIFIED_NAME_PATTERN = "^([^/]+)/([^/]+)$"
+PROJECT_QUALIFIED_NAME_PATTERN = "^((?P<workspace>[^/]+)/){0,1}(?P<project>[^/]+)$"


### PR DESCRIPTION
User is now allowed to provide project name without workspace `common/fastai-integration` -> `fastai-integration`