### PR TITLE
Moves "Done" in Run.stop to after operation syncing thread is stopped

### DIFF
--- a/neptune/new/run.py
+++ b/neptune/new/run.py
@@ -311,10 +311,10 @@ class Run(AbstractContextManager):
         click.echo(f"Shutting down background jobs, please wait a moment...")
         self._bg_job.stop()
         self._bg_job.join(seconds)
-        click.echo("Done!")
         with self._lock:
             sec_left = None if seconds is None else seconds - (time.time() - ts)
             self._op_processor.stop(sec_left)
+        click.echo("Done!")
         self._state = RunState.STOPPED
 
     def get_structure(self) -> Dict[str, Any]:


### PR DESCRIPTION
Motivation: when the user sees "Done" printed, they should know that stopping has definitively finished, without any potential for deadlock, I/O errors, you name it.