### PR TITLE
Checking current working directory instead of entrypoint when looking for git repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## neptune-client 0.10.2 [UNRELEASED]
 
+### Breaking changes
+- Checking current working directory instead of entrypoint when looking for git repository ([#631](https://github.com/neptune-ai/neptune-client/pull/631))
+
 ### Features
 - Added NEPTUNE_MONITORING_NAMEPSACE environment variable ([#623](https://github.com/neptune-ai/neptune-client/pull/623))
 

--- a/neptune/new/internal/utils/git.py
+++ b/neptune/new/internal/utils/git.py
@@ -56,9 +56,4 @@ def get_git_info(repo_path=None):
 
 
 def discover_git_repo_location() -> Optional[str]:
-    # pylint:disable=bad-option-value,import-outside-toplevel
-    import __main__
-
-    if hasattr(__main__, '__file__'):
-        return os.path.dirname(os.path.abspath(__main__.__file__))
-    return None
+    return os.getcwd()


### PR DESCRIPTION
Made more consistent with docs: https://docs.neptune.ai/you-should-know/what-can-you-log-and-display#git-information
> If you start a Run from a directory that is a part of the git repo, Neptune will automatically find the .git directory and log information from it.

For example currently when working with Kedro where we run `kedro run` it starts git repository lookup in virtual env path: `/home/rafal/envs/kedro-integration/bin/kedro` instead of current working directory.