### PR TITLE
adapt e2e test to pytorch-lightning 1.6 release

### DIFF
--- a/e2e_tests/integrations/test_pytorch_lightning.py
+++ b/e2e_tests/integrations/test_pytorch_lightning.py
@@ -33,7 +33,7 @@ class TestPytorchLightning(BaseE2ETest):
         # epoch are logged in steps [1, 1, ...., 2, 2, ..., 3, 3 ...]
         logged_epochs = list(pytorch_run["custom_prefix/epoch"].fetch_values()["value"])
         assert sorted(logged_epochs) == logged_epochs
-        assert set(logged_epochs) == {0, 1, 2}
+        assert set(logged_epochs) == {0, 1, 2, 3}
 
         assert pytorch_run.exists("custom_prefix/valid/loss")
         assert len(pytorch_run["custom_prefix/valid/loss"].fetch_values()) == 3


### PR DESCRIPTION
cf. Backward Incompatible Changes -> Re-define the current_epoch boundary