### PR TITLE
Fix pip extras installation in integrations errror

### DIFF
--- a/neptune/new/exceptions.py
+++ b/neptune/new/exceptions.py
@@ -943,7 +943,7 @@ Looks like integration {integration_package_name} wasn't installed.
 To install, run:
     {bash}pip install {integration_package_name}{end}
 Or:
-    {bash}pip install neptune-client[{framework_name}]{end}
+    {bash}pip install "neptune-client[{framework_name}]"{end}
 
 You may also want to check the following docs page:
     - https://docs.neptune.ai/integrations-and-supported-tools/intro


### PR DESCRIPTION
In ZSH [] has special meaning and extras installation needs to be surrounded by ". This is compatible with other shells.

- Add "" to pip extras installation command in the error message.