### PR TITLE
Fix problems with timeouts in integration tests

### DIFF
--- a/.github/actions/publish-tests-result/action.yml
+++ b/.github/actions/publish-tests-result/action.yml
@@ -1,0 +1,21 @@
+---
+name: Publish tests
+description: Check python code
+runs:
+    using: "composite"
+    steps:
+      - name: Get artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: test-artifacts
+          path: ./test-results
+
+      - name: Display test artifacts
+        run: ls -R ./test-results
+        shell: bash
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          junit_files: "**/test-results/test-*.xml"

--- a/.github/actions/tests-e2e/action.yml
+++ b/.github/actions/tests-e2e/action.yml
@@ -30,43 +30,43 @@ runs:
         env:
           NEPTUNE_API_TOKEN: ${{ inputs.sa-api-token}}
         run: |
-          pytest -v ./e2e_tests -m "base" \
-          --timeout=600  --timeout_method=thread \
+          pytest -v ./e2e_tests -m "not integrations" \
+          --timeout=600 --timeout_method=thread \
           --junitxml="./test-results/test-e2e-base-${{ matrix.os }}-${{ matrix.python-version }}.xml"
         shell: bash
-#
-#      - name: E2E - Integrations
-#        env:
-#          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token }}
-#        run: |
-#          pytest -v ./e2e_tests -m integrations \
-#          --timeout=600  --timeout_method=thread \
-#          --junitxml="./test-results/test-e2e-management-${{ matrix.os }}-${{ matrix.python-version }}.xml"
-#        shell: bash
-#
-#      - name: Test Fast.ai integration
-#        uses: neptune-ai/neptune-fastai/.github/actions/e2e@master
-#        with:
-#          working_directory: neptune_fastai
-#        env:
-#          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
-#          NEPTUNE_PROJECT: e2e-tests/e2e
-#
-#      - name: Test Kedro integration
-#        uses: neptune-ai/kedro-neptune/.github/actions/e2e@main
-#        with:
-#          working_directory: neptune_kedro
-#        env:
-#          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
-#          NEPTUNE_PROJECT: e2e-tests/kedro-neptune-e2e
-#
-#      - name: Test Prophet integration
-#        uses: neptune-ai/neptune-prophet/.github/actions/e2e@main
-#        with:
-#          working_directory: neptune_prophet
-#        env:
-#          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
-#          NEPTUNE_PROJECT: e2e-tests/e2e
+
+      - name: E2E - Integrations
+        env:
+          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token }}
+        run: |
+          pytest -v ./e2e_tests -m integrations \
+          --timeout=600  --timeout_method=thread \
+          --junitxml="./test-results/test-e2e-management-${{ matrix.os }}-${{ matrix.python-version }}.xml"
+        shell: bash
+
+      - name: Test Fast.ai integration
+        uses: neptune-ai/neptune-fastai/.github/actions/e2e@master
+        with:
+          working_directory: neptune_fastai
+        env:
+          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
+          NEPTUNE_PROJECT: e2e-tests/e2e
+
+      - name: Test Kedro integration
+        uses: neptune-ai/kedro-neptune/.github/actions/e2e@main
+        with:
+          working_directory: neptune_kedro
+        env:
+          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
+          NEPTUNE_PROJECT: e2e-tests/kedro-neptune-e2e
+
+      - name: Test Prophet integration
+        uses: neptune-ai/neptune-prophet/.github/actions/e2e@main
+        with:
+          working_directory: neptune_prophet
+        env:
+          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
+          NEPTUNE_PROJECT: e2e-tests/e2e
 
       - name: Display test artifacts
         if: always()

--- a/.github/actions/tests-e2e/action.yml
+++ b/.github/actions/tests-e2e/action.yml
@@ -26,18 +26,26 @@ runs:
           pip list
         shell: bash
 
+      - name: Create dir for test results
+        run: mkdir ./test-results
+        shell: bash
+
       - name: E2E - Service Accounts
         env:
           NEPTUNE_API_TOKEN: ${{ inputs.sa-api-token}}
         run: |
-          pytest ./e2e_tests --timeout=600  --timeout_method=thread -m "not integrations"
+          pytest -v ./e2e_tests \
+          --timeout=600  --timeout_method=thread -m "not integrations"
+          --junitxml="./test-results/test-e2e-base-${{ matrix.os }}-${{ matrix.python-version }}.xml" \
         shell: bash
 
       - name: E2E - Integrations
         env:
           NEPTUNE_API_TOKEN: ${{ inputs.user-api-token }}
         run: |
-          pytest ./e2e_tests --timeout=600  --timeout_method=thread -m integrations
+          pytest -v ./e2e_tests \
+          --timeout=600  --timeout_method=thread -m integrations
+          --junitxml="./test-results/test-e2e-management-${{ matrix.os }}-${{ matrix.python-version }}.xml" \
         shell: bash
 
       - name: Test Fast.ai integration
@@ -63,3 +71,14 @@ runs:
         env:
           NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
           NEPTUNE_PROJECT: e2e-tests/e2e
+
+      - name: Display test artifacts
+        if: always()
+        run: ls -R ./test-results
+        shell: bash
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-artifacts
+          path: ./test-results

--- a/.github/actions/tests-e2e/action.yml
+++ b/.github/actions/tests-e2e/action.yml
@@ -34,43 +34,43 @@ runs:
         env:
           NEPTUNE_API_TOKEN: ${{ inputs.sa-api-token}}
         run: |
-          pytest -v ./e2e_tests \
-          --timeout=600  --timeout_method=thread -m "not integrations"
-          --junitxml="./test-results/test-e2e-base-${{ matrix.os }}-${{ matrix.python-version }}.xml" \
+          pytest -v ./e2e_tests -m "base" \
+          --timeout=600  --timeout_method=thread \
+          --junitxml="./test-results/test-e2e-base-${{ matrix.os }}-${{ matrix.python-version }}.xml"
         shell: bash
-
-      - name: E2E - Integrations
-        env:
-          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token }}
-        run: |
-          pytest -v ./e2e_tests \
-          --timeout=600  --timeout_method=thread -m integrations
-          --junitxml="./test-results/test-e2e-management-${{ matrix.os }}-${{ matrix.python-version }}.xml" \
-        shell: bash
-
-      - name: Test Fast.ai integration
-        uses: neptune-ai/neptune-fastai/.github/actions/e2e@master
-        with:
-          working_directory: neptune_fastai
-        env:
-          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
-          NEPTUNE_PROJECT: e2e-tests/e2e
-
-      - name: Test Kedro integration
-        uses: neptune-ai/kedro-neptune/.github/actions/e2e@main
-        with:
-          working_directory: neptune_kedro
-        env:
-          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
-          NEPTUNE_PROJECT: e2e-tests/kedro-neptune-e2e
-
-      - name: Test Prophet integration
-        uses: neptune-ai/neptune-prophet/.github/actions/e2e@main
-        with:
-          working_directory: neptune_prophet
-        env:
-          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
-          NEPTUNE_PROJECT: e2e-tests/e2e
+#
+#      - name: E2E - Integrations
+#        env:
+#          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token }}
+#        run: |
+#          pytest -v ./e2e_tests -m integrations \
+#          --timeout=600  --timeout_method=thread \
+#          --junitxml="./test-results/test-e2e-management-${{ matrix.os }}-${{ matrix.python-version }}.xml"
+#        shell: bash
+#
+#      - name: Test Fast.ai integration
+#        uses: neptune-ai/neptune-fastai/.github/actions/e2e@master
+#        with:
+#          working_directory: neptune_fastai
+#        env:
+#          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
+#          NEPTUNE_PROJECT: e2e-tests/e2e
+#
+#      - name: Test Kedro integration
+#        uses: neptune-ai/kedro-neptune/.github/actions/e2e@main
+#        with:
+#          working_directory: neptune_kedro
+#        env:
+#          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
+#          NEPTUNE_PROJECT: e2e-tests/kedro-neptune-e2e
+#
+#      - name: Test Prophet integration
+#        uses: neptune-ai/neptune-prophet/.github/actions/e2e@main
+#        with:
+#          working_directory: neptune_prophet
+#        env:
+#          NEPTUNE_API_TOKEN: ${{ inputs.user-api-token}}
+#          NEPTUNE_PROJECT: e2e-tests/e2e
 
       - name: Display test artifacts
         if: always()

--- a/.github/actions/tests-e2e/action.yml
+++ b/.github/actions/tests-e2e/action.yml
@@ -26,10 +26,6 @@ runs:
           pip list
         shell: bash
 
-      - name: Create dir for test results
-        run: mkdir ./test-results
-        shell: bash
-
       - name: E2E - Service Accounts
         env:
           NEPTUNE_API_TOKEN: ${{ inputs.sa-api-token}}

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -22,7 +22,7 @@ runs:
       - name: Integration tests
         run: |
           pytest -v ./tests \
-          --timeout=120 \
+          --timeout=120 --timeout_method=thread \
           --junitxml="./test-results/test-integration-${{ matrix.os }}-${{ matrix.python-version }}.xml"
         shell: bash
 

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -19,7 +19,24 @@ runs:
           pip list
         shell: bash
 
+      - name: Create dir for test results
+        run: mkdir ./test-results
+        shell: bash
+
       - name: Integration tests
         run: |
-          pytest --timeout=120  --timeout_method=thread ./tests
+          pytest -v ./tests \
+          --junitxml="./test-results/test-integration-${{ matrix.os }}-${{ matrix.python-version }}.xml" \
+          --timeout=120
         shell: bash
+
+      - name: Display test artifacts
+        if: always()
+        run: ls -R ./test-results
+        shell: bash
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-artifacts
+          path: ./test-results

--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -19,15 +19,11 @@ runs:
           pip list
         shell: bash
 
-      - name: Create dir for test results
-        run: mkdir ./test-results
-        shell: bash
-
       - name: Integration tests
         run: |
           pytest -v ./tests \
-          --junitxml="./test-results/test-integration-${{ matrix.os }}-${{ matrix.python-version }}.xml" \
-          --timeout=120
+          --timeout=120 \
+          --junitxml="./test-results/test-integration-${{ matrix.os }}-${{ matrix.python-version }}.xml"
         shell: bash
 
       - name: Display test artifacts

--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -69,6 +69,20 @@ jobs:
           sa-api-token: ${{secrets.E2E_SERVICE_ACCOUNT_API_TOKEN}}
           user-api-token: ${{secrets.E2E_NEPTUNE_API_TOKEN}}
 
+  publish-tests:
+    needs: [test, test-e2e]
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Publish tests
+        uses: ./.github/actions/publish-tests-result
+
   notify:
     needs: [lint, test, test-e2e]
     runs-on: ubuntu-latest

--- a/.github/workflows/minimal_e2e.yml
+++ b/.github/workflows/minimal_e2e.yml
@@ -1,14 +1,9 @@
 name: Minimal E2E
-#on: [workflow_dispatch]
-on:
-  workflow_dispatch:
-  push:
-    branches-ignore:
-      - master
+on: [workflow_dispatch]
 jobs:
   test-e2e:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 40
+    timeout-minutes: 75
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/minimal_e2e.yml
+++ b/.github/workflows/minimal_e2e.yml
@@ -1,9 +1,14 @@
 name: Minimal E2E
-on: [workflow_dispatch]
+#on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - master
 jobs:
   test-e2e:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 75
+    timeout-minutes: 40
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/minimal_e2e.yml
+++ b/.github/workflows/minimal_e2e.yml
@@ -1,10 +1,5 @@
 name: Minimal E2E
-#on: [workflow_dispatch]
-on:
-  workflow_dispatch:
-  push:
-    branches-ignore:
-      - master
+on: [workflow_dispatch]
 jobs:
   test-e2e:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/minimal_e2e.yml
+++ b/.github/workflows/minimal_e2e.yml
@@ -1,16 +1,13 @@
-name: Scheduled E2E
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * *" # Run every day at arbitrary time (4:00 AM UTC)
+name: Minimal E2E
+on: [workflow_dispatch]
 jobs:
   test-e2e:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 75
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
     env:
       WORKSPACE_NAME: e2e-tests
       BUCKET_NAME: ${{ secrets.E2E_BUCKET_NAME }}
@@ -53,26 +50,3 @@ jobs:
 
       - name: Publish tests
         uses: ./.github/actions/publish-tests-result
-
-  notify:
-    needs: [test-e2e]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-    steps:
-      - uses: technote-space/workflow-conclusion-action@v2
-
-      - name: Notify about failure
-        uses: 8398a7/action-slack@v3
-        if: env.WORKFLOW_CONCLUSION != 'success'
-        with:
-          status: failure
-          fields: repo,message,author,job,eventName,took
-
-      - name: Notify about success
-        uses: 8398a7/action-slack@v3
-        if: env.WORKFLOW_CONCLUSION == 'success'
-        with:
-          status: success
-          fields: repo,message,author,job,eventName,took

--- a/.github/workflows/minimal_e2e.yml
+++ b/.github/workflows/minimal_e2e.yml
@@ -1,5 +1,10 @@
 name: Minimal E2E
-on: [workflow_dispatch]
+#on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - master
 jobs:
   test-e2e:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-lates]
+        os: [ubuntu-latest]
         python-version: ["3.7", "3.10"] # minimum, maximum
     steps:
       - name: Checkout repository

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-lates]
         python-version: ["3.7", "3.10"] # minimum, maximum
     steps:
       - name: Checkout repository
@@ -26,3 +26,17 @@ jobs:
 
       - name: Tests
         uses: ./.github/actions/tests
+
+  publish-tests:
+    needs: [test]
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Publish tests
+        uses: ./.github/actions/publish-tests-result

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,20 @@ jobs:
           sa-api-token: ${{secrets.E2E_SERVICE_ACCOUNT_API_TOKEN}}
           user-api-token: ${{secrets.E2E_NEPTUNE_API_TOKEN}}
 
+  publish-tests:
+    needs: [test, test-e2e]
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      checks: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Publish tests
+        uses: ./.github/actions/publish-tests-result
+
   notify:
     needs: [lint, test, test-e2e]
     runs-on: ubuntu-latest

--- a/e2e_tests/standard/test_base.py
+++ b/e2e_tests/standard/test_base.py
@@ -22,6 +22,7 @@ from e2e_tests.base import AVAILABLE_CONTAINERS, BaseE2ETest, fake
 from neptune.new.metadata_containers import MetadataContainer
 
 
+@pytest.mark.base
 class TestAtoms(BaseE2ETest):
     @pytest.mark.parametrize("container", AVAILABLE_CONTAINERS, indirect=True)
     @pytest.mark.parametrize(

--- a/e2e_tests/standard/test_base.py
+++ b/e2e_tests/standard/test_base.py
@@ -22,7 +22,6 @@ from e2e_tests.base import AVAILABLE_CONTAINERS, BaseE2ETest, fake
 from neptune.new.metadata_containers import MetadataContainer
 
 
-@pytest.mark.base
 class TestAtoms(BaseE2ETest):
     @pytest.mark.parametrize("container", AVAILABLE_CONTAINERS, indirect=True)
     @pytest.mark.parametrize(

--- a/tests/neptune/internal/channels/test_channels_values_sender.py
+++ b/tests/neptune/internal/channels/test_channels_values_sender.py
@@ -20,7 +20,6 @@ import time
 import unittest
 
 import mock
-import pytest
 
 from neptune.internal.channels.channels import (
     ChannelIdWithValues,
@@ -305,14 +304,9 @@ class TestChannelsValuesSender(unittest.TestCase):
             ),
         )
 
-    __TIMEOUT = 0.1
-
-    # Using pytest-timeout because Python 2.7 does not support timeouts on acquiring semaphores.
-    # Can be refactored once Python 2 support is dropped.
-    @pytest.mark.timeout(10 * __TIMEOUT)
     @mock.patch(
         "neptune.internal.channels.channels_values_sender.ChannelsValuesSendingThread._SLEEP_TIME",
-        __TIMEOUT,
+        0.1,
     )
     def test_send_when_waiting_for_next_value_timed_out(self):
         # given

--- a/tests/neptune/new/client/abstract_experiment_test_mixin.py
+++ b/tests/neptune/new/client/abstract_experiment_test_mixin.py
@@ -22,8 +22,6 @@ from abc import abstractmethod
 from io import StringIO
 from unittest.mock import Mock
 
-import pytest
-
 from neptune.new.exceptions import (
     MetadataInconsistency,
     MissingFieldException,
@@ -85,7 +83,6 @@ class AbstractExperimentTestMixin:
                 os.listdir(f".neptune/async/{exp_dir}/{execution_dir}"),
             )
 
-    @pytest.mark.timeout(10)
     def test_async_mode_wait_on_dead(self):
         with self.call_init(mode="async", flush_period=0.5) as exp:
             exp._op_processor._backend.execute_operations = Mock(side_effect=ValueError)
@@ -95,7 +92,6 @@ class AbstractExperimentTestMixin:
             with self.assertRaises(NeptuneSynchronizationAlreadyStoppedException):
                 exp.wait()
 
-    @pytest.mark.timeout(10)
     def test_async_mode_die_during_wait(self):
         with self.call_init(mode="async", flush_period=1) as exp:
             exp._op_processor._backend.execute_operations = Mock(side_effect=ValueError)
@@ -103,7 +99,6 @@ class AbstractExperimentTestMixin:
             with self.assertRaises(NeptuneSynchronizationAlreadyStoppedException):
                 exp.wait()
 
-    @pytest.mark.timeout(10)
     def test_async_mode_stop_on_dead(self):
         stream = StringIO()
         with contextlib.redirect_stdout(stream):


### PR DESCRIPTION
* Some tests were decorated to timeout after 10s, those tests caused problems, they will be timeouted by default as all other tests (we keep 120s).
* introduced bot for publishing summary of tests
* junitxml files from all tests are available in artifacts