### PR TITLE
Fix Artifact Tracking SQL Injection Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 - Update jsonschema requirement with explicit `format` specifier ([#1010](https://github.com/neptune-ai/neptune-client/pull/1010))
+- Escape inputs to SQL in Artifact LocalFileHashStorage ([#1034](https://github.com/neptune-ai/neptune-client/pull/1034))
 
 ### Changes
 - More consistent and strict way of git repository, source files and entrypoint detection ([#1007](https://github.com/neptune-ai/neptune-client/pull/1007))

--- a/src/neptune/new/internal/artifacts/local_file_hash_storage.py
+++ b/src/neptune/new/internal/artifacts/local_file_hash_storage.py
@@ -33,13 +33,13 @@ class LocalFileHashStorage:
         self.session = sql.connect(str(db_path))
         self.cursor: sql.Cursor = self.session.cursor()
         self.cursor.execute(
-            "CREATE TABLE IF NOT EXISTS local_file_hashes" " (file_path text, file_hash text, modification_date text)"
+            "CREATE TABLE IF NOT EXISTS local_file_hashes (file_path text, file_hash text, modification_date text)"
         )
         self.session.commit()
 
     def insert(self, path: Path, computed_hash: str, modification_date: str):
         self.cursor.execute(
-            f"INSERT INTO local_file_hashes" f" (file_path, file_hash, modification_date)" f" VALUES (?, ?, ?)",
+            "INSERT INTO local_file_hashes (file_path, file_hash, modification_date) VALUES (?, ?, ?)",
             (str(path), computed_hash, modification_date),
         )
         self.session.commit()
@@ -48,7 +48,7 @@ class LocalFileHashStorage:
         found = [
             LocalFileHashStorage.LocalFileHash(*row)
             for row in self.cursor.execute(
-                f"SELECT file_path, file_hash, modification_date" f" FROM local_file_hashes" f" WHERE file_path = ?",
+                "SELECT file_path, file_hash, modification_date FROM local_file_hashes WHERE file_path = ?",
                 (str(path),),
             )
         ]
@@ -57,7 +57,7 @@ class LocalFileHashStorage:
 
     def update(self, path: Path, computed_hash: str, modification_date: str):
         self.cursor.execute(
-            f"UPDATE local_file_hashes" f" SET file_hash=?, modification_date=?" f" WHERE file_path = ?",
+            "UPDATE local_file_hashes SET file_hash=?, modification_date=? WHERE file_path = ?",
             (computed_hash, modification_date, str(path)),
         )
         self.session.commit()

--- a/src/neptune/new/internal/artifacts/local_file_hash_storage.py
+++ b/src/neptune/new/internal/artifacts/local_file_hash_storage.py
@@ -39,9 +39,8 @@ class LocalFileHashStorage:
 
     def insert(self, path: Path, computed_hash: str, modification_date: str):
         self.cursor.execute(
-            f"INSERT INTO local_file_hashes"
-            f" (file_path, file_hash, modification_date)"
-            f" VALUES (?, ?, ?)", (str(path), computed_hash, modification_date)
+            f"INSERT INTO local_file_hashes" f" (file_path, file_hash, modification_date)" f" VALUES (?, ?, ?)",
+            (str(path), computed_hash, modification_date),
         )
         self.session.commit()
 
@@ -49,9 +48,8 @@ class LocalFileHashStorage:
         found = [
             LocalFileHashStorage.LocalFileHash(*row)
             for row in self.cursor.execute(
-                f"SELECT file_path, file_hash, modification_date"
-                f" FROM local_file_hashes"
-                f" WHERE file_path = ?", (str(path),)
+                f"SELECT file_path, file_hash, modification_date" f" FROM local_file_hashes" f" WHERE file_path = ?",
+                (str(path),),
             )
         ]
 
@@ -59,8 +57,7 @@ class LocalFileHashStorage:
 
     def update(self, path: Path, computed_hash: str, modification_date: str):
         self.cursor.execute(
-            f"UPDATE local_file_hashes"
-            f" SET file_hash=?, modification_date=?"
-            f" WHERE file_path = ?", (computed_hash, modification_date, str(path))
+            f"UPDATE local_file_hashes" f" SET file_hash=?, modification_date=?" f" WHERE file_path = ?",
+            (computed_hash, modification_date, str(path)),
         )
         self.session.commit()

--- a/src/neptune/new/internal/artifacts/local_file_hash_storage.py
+++ b/src/neptune/new/internal/artifacts/local_file_hash_storage.py
@@ -41,7 +41,7 @@ class LocalFileHashStorage:
         self.cursor.execute(
             f"INSERT INTO local_file_hashes"
             f" (file_path, file_hash, modification_date)"
-            f" VALUES ('{str(path)}', '{computed_hash}', '{modification_date}')"
+            f" VALUES (?, ?, ?)", (str(path), computed_hash, modification_date)
         )
         self.session.commit()
 
@@ -51,7 +51,7 @@ class LocalFileHashStorage:
             for row in self.cursor.execute(
                 f"SELECT file_path, file_hash, modification_date"
                 f" FROM local_file_hashes"
-                f" WHERE file_path = '{str(path)}'"
+                f" WHERE file_path = ?", (str(path),)
             )
         ]
 
@@ -60,7 +60,7 @@ class LocalFileHashStorage:
     def update(self, path: Path, computed_hash: str, modification_date: str):
         self.cursor.execute(
             f"UPDATE local_file_hashes"
-            f" SET file_hash='{computed_hash}', modification_date='{modification_date}'"
-            f" WHERE file_path = '{str(path)}'"
+            f" SET file_hash=?, modification_date=?"
+            f" WHERE file_path = ?", (computed_hash, modification_date, str(path))
         )
         self.session.commit()


### PR DESCRIPTION
Hey everyone,

Artifact tracking appears to be broken when a parent directory contains a SQL special character. The code that I modified (`local_file_hash_storage.py`) assumed that Unix paths could be injected without being escaped into SQL statements -- so I just did the standard `?` SQL escaping. If you are tracking artifacts in a directory that has a parent that contains, for example, `'` (e.g. `Frederick's Workspace/`) would break the SQL queries necessary for tracking artifacts.