### PR TITLE
adjust e2e tests for lightning CI

### DIFF
--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -33,6 +33,7 @@ from neptune.management import (
     add_project_service_account,
     create_project,
 )
+from neptune.management.exceptions import ProjectNameCollision
 from neptune.management.internal.utils import normalize_project_name
 from neptune.new import init_project
 
@@ -41,48 +42,66 @@ fake = Faker()
 
 @pytest.fixture(scope="session")
 def environment():
-    raw_env = RawEnvironment()
-    workspace = raw_env.workspace_name
-    admin_token = raw_env.admin_neptune_api_token
-    user = raw_env.user_username
-    service_account_name = raw_env.service_account_name
+    # check if lightning env variable is present
+    project_env_var = os.getenv("NEPTUNE_LIGHTNING_ECOSYSTEM_CI_PROJECT", "")
 
-    project_name = a_project_name(project_slug=fake.slug())
+    if project_env_var:
+        workspace, project_name = project_env_var.split("/")
+        user_token = os.getenv("NEPTUNE_API_TOKEN")
+        admin_token = user_token
+        admin = ""
+        user = ""
+        service_account_name = ""
+
+    else:
+        raw_env = RawEnvironment()
+        workspace = raw_env.workspace_name
+        project_name = a_project_name(project_slug=fake.slug())
+        user_token = raw_env.neptune_api_token
+        admin_token = raw_env.admin_neptune_api_token
+        admin = raw_env.admin_username
+        user = raw_env.user_username
+        service_account_name = raw_env.service_account_name
+
     project_identifier = normalize_project_name(name=project_name, workspace=workspace)
 
-    created_project_identifier = create_project(
-        name=project_name,
-        visibility="priv",
-        workspace=workspace,
-        api_token=admin_token,
-    )
+    try:
+        created_project_identifier = create_project(
+            name=project_name,
+            visibility="priv",
+            workspace=workspace,
+            api_token=admin_token,
+        )
 
-    time.sleep(10)
+        time.sleep(10)
 
-    add_project_member(
-        name=created_project_identifier,
-        username=user,
-        # pylint: disable=no-member
-        role="contributor",
-        api_token=admin_token,
-    )
+        add_project_member(
+            name=created_project_identifier,
+            username=user,
+            # pylint: disable=no-member
+            role="contributor",
+            api_token=admin_token,
+        )
 
-    add_project_service_account(
-        name=created_project_identifier,
-        service_account_name=service_account_name,
-        # pylint: disable=no-member
-        role="contributor",
-        api_token=admin_token,
-    )
+        add_project_service_account(
+            name=created_project_identifier,
+            service_account_name=service_account_name,
+            # pylint: disable=no-member
+            role="contributor",
+            api_token=admin_token,
+        )
+
+    except ProjectNameCollision:
+        created_project_identifier = project_name
 
     yield Environment(
         workspace=workspace,
         project=project_identifier,
-        user_token=raw_env.neptune_api_token,
+        user_token=user_token,
         admin_token=admin_token,
-        admin=raw_env.admin_username,
+        admin=admin,
         user=user,
-        service_account=raw_env.service_account_name,
+        service_account=service_account_name,
     )
 
     project = init_project(name=created_project_identifier, api_token=admin_token)

--- a/e2e_tests/integrations/test_lightning.py
+++ b/e2e_tests/integrations/test_lightning.py
@@ -36,8 +36,12 @@ from e2e_tests.base import BaseE2ETest
 
 LIGHTNING_ECOSYSTEM_ENV_PROJECT = "NEPTUNE_LIGHTNING_ECOSYSTEM_CI_PROJECT"
 
-skip_if_on_regular_env = pytest.mark.skipif(LIGHTNING_ECOSYSTEM_ENV_PROJECT not in os.environ)
-skip_if_on_lightning_ecosystem = pytest.mark.skipif(LIGHTNING_ECOSYSTEM_ENV_PROJECT in os.environ)
+skip_if_on_regular_env = pytest.mark.skipif(
+    LIGHTNING_ECOSYSTEM_ENV_PROJECT not in os.environ, reason="Tests weren't invoked in Lightning Ecosystem CI"
+)
+skip_if_on_lightning_ecosystem = pytest.mark.skipif(
+    LIGHTNING_ECOSYSTEM_ENV_PROJECT in os.environ, reason="Tests invoked in Lightning Ecosystem CI"
+)
 
 
 class RandomDataset(Dataset):

--- a/e2e_tests/integrations/test_lightning.py
+++ b/e2e_tests/integrations/test_lightning.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 # pylint: disable=redefined-outer-name
+import os
 import re
 
 import pytest
@@ -32,6 +33,11 @@ from torch.utils.data import (
 
 import neptune.new as neptune
 from e2e_tests.base import BaseE2ETest
+
+LIGHTNING_ECOSYSTEM_ENV_PROJECT = "NEPTUNE_LIGHTNING_ECOSYSTEM_CI_PROJECT"
+
+skip_if_on_regular_env = pytest.mark.skipif(LIGHTNING_ECOSYSTEM_ENV_PROJECT not in os.environ)
+skip_if_on_lightning_ecosystem = pytest.mark.skipif(LIGHTNING_ECOSYSTEM_ENV_PROJECT in os.environ)
 
 
 class RandomDataset(Dataset):
@@ -76,10 +82,9 @@ class BoringModel(LightningModule):
         return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
 
-@pytest.fixture(scope="session")
-def pytorch_run(environment):
+def prepare(project):
     # given
-    run = neptune.init_run(name="Pytorch-Lightning integration", project=environment.project)
+    run = neptune.init_run(name="Pytorch-Lightning integration", project=project)
     # and
     model_checkpoint = ModelCheckpoint(
         dirpath="my_model/checkpoints/",
@@ -110,13 +115,23 @@ def pytorch_run(environment):
     trainer.test(model, dataloaders=test_data)
     run.sync()
 
-    yield run
+    return run
+
+
+@pytest.fixture(scope="session")
+def model_in_regular_env(environment):
+    yield prepare(project=environment.project)
+
+
+@pytest.fixture(scope="session")
+def model_in_lightning_ci_project():
+    yield prepare(project=os.getenv("NEPTUNE_LIGHTNING_ECOSYSTEM_CI_PROJECT"))
 
 
 @pytest.mark.integrations
 @pytest.mark.lightning
 class TestPytorchLightning(BaseE2ETest):
-    def test_logging_values(self, pytorch_run):
+    def _test_logging_values(self, pytorch_run):
         # correct integration version is logged
         if pytorch_run.exists("source_code/integrations/lightning"):
             logged_version = pytorch_run["source_code/integrations/lightning"].fetch()
@@ -127,7 +142,15 @@ class TestPytorchLightning(BaseE2ETest):
         assert pytorch_run.exists("custom_prefix/valid/loss")
         assert len(pytorch_run["custom_prefix/valid/loss"].fetch_values()) == 3
 
-    def test_saving_models(self, pytorch_run):
+    @skip_if_on_lightning_ecosystem
+    def test_logging_values(self, model_in_regular_env):
+        self._test_logging_values(model_in_regular_env)
+
+    @skip_if_on_regular_env
+    def test_logging_values_in_lightning_ci(self, model_in_lightning_ci_project):
+        self._test_logging_values(model_in_lightning_ci_project)
+
+    def _test_saving_models(self, pytorch_run):
         best_model_path = pytorch_run["custom_prefix/model/best_model_path"].fetch()
         assert re.match(
             r".*my_model/checkpoints/epoch=.*-valid/loss=.*\.ckpt$",
@@ -140,3 +163,11 @@ class TestPytorchLightning(BaseE2ETest):
         checkpoints = pytorch_run["custom_prefix/model/checkpoints"].fetch()
         assert all((checkpoint.startswith("epoch=") for checkpoint in checkpoints))
         assert len(checkpoints) == 2
+
+    @skip_if_on_lightning_ecosystem
+    def test_saving_models(self, model_in_regular_env):
+        self._test_saving_models(model_in_regular_env)
+
+    @skip_if_on_regular_env
+    def test_saving_models_in_lightning_ci(self, model_in_lightning_ci_project):
+        self._test_saving_models(model_in_lightning_ci_project)

--- a/e2e_tests/integrations/test_lightning.py
+++ b/e2e_tests/integrations/test_lightning.py
@@ -114,6 +114,7 @@ def pytorch_run(environment):
 
 
 @pytest.mark.integrations
+@pytest.mark.lightning
 class TestPytorchLightning(BaseE2ETest):
     def test_logging_values(self, pytorch_run):
         # correct integration version is logged

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -3,3 +3,4 @@ markers =
     s3: a test is using AWS S3
     management: a test is using Management API
     integrations: a test is testing an integration
+    lightning: a test is supposed to run with Lightning EcoSystem CI

--- a/e2e_tests/pytest.ini
+++ b/e2e_tests/pytest.ini
@@ -3,4 +3,4 @@ markers =
     s3: a test is using AWS S3
     management: a test is using Management API
     integrations: a test is testing an integration
-    lightning: a test is supposed to run with Lightning EcoSystem CI
+    lightning: a test is testing pytorch-lightning integration (can also run with Lightning EcoSystem)


### PR DESCRIPTION
- add a new mark to designate relevant tests
- use conditional environment fixture creation to avoid creating new project every time