### PR TITLE
Async logging in StdStreamCaptureLogger

### DIFF
--- a/src/neptune/new/internal/streams/std_stream_capture_logger.py
+++ b/src/neptune/new/internal/streams/std_stream_capture_logger.py
@@ -41,7 +41,7 @@ class StdStreamCaptureLogger:
     def __getattr__(self, attr):
         return getattr(self.stream, attr)
 
-    def close(self, wait_for_all_logs=False):
+    def close(self, wait_for_all_logs=True):
         if not wait_for_all_logs:
             self.enabled = False
         self._log_data_queue.put_nowait(None)
@@ -64,7 +64,7 @@ class StdoutCaptureLogger(StdStreamCaptureLogger):
         super().__init__(container, attribute_name, sys.stdout)
         sys.stdout = self
 
-    def close(self, wait_for_all_logs=False):
+    def close(self, wait_for_all_logs=True):
         sys.stdout = self.stream
         super().close(wait_for_all_logs)
 
@@ -74,6 +74,6 @@ class StderrCaptureLogger(StdStreamCaptureLogger):
         super().__init__(container, attribute_name, sys.stderr)
         sys.stderr = self
 
-    def close(self, wait_for_all_logs=False):
+    def close(self, wait_for_all_logs=True):
         sys.stderr = self.stream
         super().close(wait_for_all_logs)

--- a/src/neptune/new/internal/streams/std_stream_capture_logger.py
+++ b/src/neptune/new/internal/streams/std_stream_capture_logger.py
@@ -16,6 +16,7 @@
 
 import sys
 import threading
+from queue import Queue
 from typing import TextIO
 
 from neptune.new.logging import Logger as NeptuneLogger
@@ -28,24 +29,34 @@ class StdStreamCaptureLogger:
         self.stream = stream
         self._thread_local = threading.local()
         self.enabled = True
+        self._log_data_queue = Queue()
+        self._finished_logging = threading.Event()
+        self._logging_thread = threading.Thread(target=self.__proces_logs, daemon=True)
+        self._logging_thread.start()
 
     def write(self, data: str):
-        if not hasattr(self._thread_local, "inside_write"):
-            self._thread_local.inside_write = False
-
         self.stream.write(data)
-        if self.enabled and not self._thread_local.inside_write:
-            try:
-                self._thread_local.inside_write = True
-                self._logger.log(data)
-            finally:
-                self._thread_local.inside_write = False
+        self._log_data_queue.put_nowait(data)
 
     def __getattr__(self, attr):
         return getattr(self.stream, attr)
 
-    def close(self):
+    def close(self, wait_for_all_logs=False):
+        if not wait_for_all_logs:
+            self.enabled = False
+        self._log_data_queue.put_nowait(None)
+        self._finished_logging.wait()
         self.enabled = False
+
+    def __proces_logs(self):
+        try:
+            while self.enabled:
+                data = self._log_data_queue.get()
+                if data is None:
+                    break
+                self._logger.log(data)
+        finally:
+            self._finished_logging.set()
 
 
 class StdoutCaptureLogger(StdStreamCaptureLogger):
@@ -53,9 +64,9 @@ class StdoutCaptureLogger(StdStreamCaptureLogger):
         super().__init__(container, attribute_name, sys.stdout)
         sys.stdout = self
 
-    def close(self):
+    def close(self, wait_for_all_logs=False):
         sys.stdout = self.stream
-        super().close()
+        super().close(wait_for_all_logs)
 
 
 class StderrCaptureLogger(StdStreamCaptureLogger):
@@ -63,6 +74,6 @@ class StderrCaptureLogger(StdStreamCaptureLogger):
         super().__init__(container, attribute_name, sys.stderr)
         sys.stderr = self
 
-    def close(self):
+    def close(self, wait_for_all_logs=False):
         sys.stderr = self.stream
-        super().close()
+        super().close(wait_for_all_logs)

--- a/tests/unit/neptune/new/internal/test_streams.py
+++ b/tests/unit/neptune/new/internal/test_streams.py
@@ -46,7 +46,7 @@ class TestStdStreamCaptureLogger(unittest.TestCase):
             logger = StdoutCaptureLogger(mock_run, attr_name)
             stdout_fp = sys.stdout
             print("testing", file=stdout_fp)
-            logger.close()
+            logger.close(wait_for_all_logs=True)
 
             self.assertListEqual(
                 mock_run[attr_name].log.call_args_list,

--- a/tests/unit/neptune/new/internal/test_streams.py
+++ b/tests/unit/neptune/new/internal/test_streams.py
@@ -46,7 +46,7 @@ class TestStdStreamCaptureLogger(unittest.TestCase):
             logger = StdoutCaptureLogger(mock_run, attr_name)
             stdout_fp = sys.stdout
             print("testing", file=stdout_fp)
-            logger.close(wait_for_all_logs=True)
+            logger.close()
 
             self.assertListEqual(
                 mock_run[attr_name].log.call_args_list,

--- a/tests/unit/neptune/new/internal/test_streams.py
+++ b/tests/unit/neptune/new/internal/test_streams.py
@@ -31,7 +31,7 @@ class TestStdStreamCaptureLogger(unittest.TestCase):
             logger = StdoutCaptureLogger(mock_run, attr_name)
             stdout_fp = sys.stdout
             print("testing", file=stdout_fp)
-            logger.close()
+            logger.close(wait_for_all_logs=True)
 
             self.assertListEqual(
                 mock_run[attr_name].log.call_args_list,


### PR DESCRIPTION
StdStreamCaptureLogger now logs asynchronously to avoid deadlock.