### PR TITLE
Add neptune-aws to pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## neptune-client 0.17.0 [UNRELEASED]
+
+### Features
+
+- Make neptune-aws package installable as `pip install neptune[aws]`.
+
 ## neptune-client 0.16.16
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,10 @@ neptune-tensorflow-keras = { version = "*", optional = true }
 neptune-xgboost = { version = "*", optional = true }
 transformers = { version = "*", optional = true }
 zenml = { version = "*", optional = true, python = "<3.9" }
+neptune-aws = { version = "*", optional = true }
 
 [tool.poetry.extras]
+aws = ["neptune-aws"]
 fastai = ["neptune-fastai"]
 kedro = ["kedro-neptune"]
 lightgbm = ["neptune-lightgbm"]

--- a/src/neptune/new/integrations/aws/__init__.py
+++ b/src/neptune/new/integrations/aws/__init__.py
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2022, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+try:
+    from neptune_aws.impl import *  # noqa: F401,F403
+except ModuleNotFoundError as e:
+    if e.name == "neptune_aws":
+        from neptune.new.exceptions import NeptuneIntegrationNotInstalledException
+
+        raise NeptuneIntegrationNotInstalledException(
+            integration_package_name="neptune-aws", framework_name="aws"
+        ) from None
+    else:
+        raise


### PR DESCRIPTION
We have a new `neptune-aws` module, we want to be able to install it as `pip install neptune[aws]`. 

**Notice:** We are still waiting for Conda to have our package, it's already on PyPI.