### PR TITLE
Duplicated source link removal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,6 @@ packages = [
 
 [tool.poetry.urls]
 "Tracker" = "https://github.com/neptune-ai/neptune-client/issues"
-"Source" = "https://github.com/neptune-ai/neptune-client"
 "Documentation" = "https://docs.neptune.ai/"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
## Description
We have duplicated links on our PyPI site: https://pypi.org/project/neptune-client/
<img width="243" alt="Screenshot 2023-02-02 at 11 33 22" src="https://user-images.githubusercontent.com/917619/216301466-8c7fdb4c-1236-4c01-ba49-81cfdbb8abba.png">


## Before submitting checklist

- [x] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [x] Did you **asked the docs owner** to review all the updated user-facing interfaces?
