### PR TITLE
Fix-long-filenames for docker arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [UNRELEASED] neptune 1.1.1
+
+### Fixes
+- Fixed handling errors in case of too long filenames provided with `sys.argv` ([#1305](https://github.com/neptune-ai/neptune-client/pull/1305))
+
 ## neptune 1.1.0
 
 ### Features

--- a/src/neptune/vendor/lib_programname.py
+++ b/src/neptune/vendor/lib_programname.py
@@ -136,10 +136,13 @@ def get_valid_executable_path_or_empty_path(arg_string: str) -> pathlib.Path:
     arg_string = remove_doctest_and_docrunner_parameters(arg_string)
     arg_string = add_python_extension_if_not_there(arg_string)
     path = pathlib.Path(arg_string)
-    if path.is_file():
-        path = path.resolve()  # .resolve does not work on a non existing file in python 3.5
-        return path
-    else:
+    try:
+        if path.is_file():
+            path = path.resolve()  # .resolve does not work on a non existing file in python 3.5
+            return path
+        else:
+            return empty_path
+    except Exception as e:
         return empty_path
 
 

--- a/tests/unit/neptune/new/test_libprogramname.py
+++ b/tests/unit/neptune/new/test_libprogramname.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2023, Neptune Labs Sp. z o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pathlib import Path
+from random import choices
+from string import ascii_lowercase
+
+from neptune.vendor.lib_programname import (
+    empty_path,
+    get_valid_executable_path_or_empty_path,
+)
+
+
+def test__non_existent():
+    # given
+    arg_string = "some/path/to/executable.py"
+
+    # when
+    found_path = get_valid_executable_path_or_empty_path(arg_string)
+
+    # then
+    assert found_path == empty_path
+
+
+def test__exists():
+    # given
+    arg_string = __file__
+
+    # when
+    found_path = get_valid_executable_path_or_empty_path(arg_string)
+
+    # then
+    assert found_path == Path(arg_string).resolve()
+
+
+def test__too_long_name():
+    # given
+    arg_string = "".join(choices(ascii_lowercase, k=1024))
+
+    # when
+    found_path = get_valid_executable_path_or_empty_path(arg_string)
+
+    # then
+    assert found_path == empty_path


### PR DESCRIPTION
Hi Neptune team, 
We're doing a quick prototype using your library and during the prototyping, we have faced the following easy to fix issue.

If you use a container and pass very long arguments to the container (in our case the orchestrator does it and we have no control over it), the input argument is captured within `sys.argv` and later in the code it will result in exception error `OSError: [Errno 36] File name too long`

In pathlib documents it also mentions that path.is_file() can throw errors like permissions ( in our case filename being too long).

Solution:
you should use error handling. This won't usually happen in the normal execution and only happens in container-based orchestrators as one of the argv could be very long.

We're currently blocked by this issue. We'd appreciate it if you can generate a quick bugfix release from this PR. This allows us to use your library in our prototype going forward.

PS. 
1. Is there documentation on how I can locally build this package?
2. I wasn't sure about the new versioning so I didn't change the CHANGELOG. Feel free to do it as you see fit. 

Thanks,
Ali


Testcase:
```
long_str = str(10**255)
path = Path(long_str)
print(path.is_file()) -> Throws an Error filename too long. 
```
