### PR TITLE
fix: Set index = false on every call repo.is_dirty

### DIFF
--- a/src/neptune/common/utils.py
+++ b/src/neptune/common/utils.py
@@ -204,7 +204,7 @@ def get_git_info(repo_path=None):
             author_name=commit.author.name,
             author_email=commit.author.email,
             commit_date=commit.committed_datetime,
-            repository_dirty=repo.is_dirty(untracked_files=True),
+            repository_dirty=repo.is_dirty(index=False, untracked_files=True),
             active_branch=active_branch,
             remote_urls=remote_urls,
         )

--- a/tests/e2e/standard/test_init.py
+++ b/tests/e2e/standard/test_init.py
@@ -117,7 +117,7 @@ class TestInitRun(BaseE2ETest):
 
         repo.git.add("some_file.txt")
 
-        assert repo.is_dirty()
+        assert repo.is_dirty(index=False)
         with neptune.init_run(project=environment.project) as run:
             run.sync()
             assert run.exists("source_code/diff")


### PR DESCRIPTION
## Before submitting checklist

- [x] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [x] Did you **ask the docs owner** to review all the user-facing changes?
