### PR TITLE
Wait for elastic index after experiment creation in trashing e2e

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ optuna = { version = "*", optional = true }
 scikit-learn = { version = "*", optional = true }
 torchvision = { version = "*", optional = true }
 accelerate = { version = "*", optional = true }
+backoff = { version = "*", optional = true }
 
 # Additional integrations
 kedro-neptune = { version = "*", optional = true, python = "<3.11" }


### PR DESCRIPTION
After switching to new elasticsearch client code in leaderboard it seems that we need to wait a bit for index refresh after creating test experiments