### PR TITLE
Fix request import

### DIFF
--- a/src/neptune/api/requests_utils.py
+++ b/src/neptune/api/requests_utils.py
@@ -21,7 +21,7 @@ from typing import (
     Dict,
 )
 
-from requests.exceptions import JSONDecodeError
+from requests.compat import JSONDecodeError
 
 if TYPE_CHECKING:
     from bravado_core.response import IncomingResponse


### PR DESCRIPTION
`JSONDecodeError` is defined here:

https://github.com/psf/requests/blob/main/src/requests/compat.py.

`requests.exceptions.JSONDecodeError` does not import  `JSONDecodeError` from `requests.compat` until v2.27.0

https://github.com/psf/requests/blob/v2.27.0/requests/exceptions.py
https://github.com/psf/requests/blob/v2.26.0/requests/exceptions.py

This PR could make neptune compatible with lower version requests.