### PR TITLE
Mention logging hours in Neptune limit exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## [UNRELEASED] neptune 1.7.1
+## [UNRELEASED] neptune 1.8.0
 
 ### Fixes
 - Add newline at the end of generated `.patch` while tracking uncommitted changes ([#1473](https://github.com/neptune-ai/neptune-client/pull/1473))
+- Clarify `NeptuneLimitExceedException` error message ([#1480](https://github.com/neptune-ai/neptune-client/pull/1480))
 
 ## neptune 1.7.0
 

--- a/src/neptune/exceptions.py
+++ b/src/neptune/exceptions.py
@@ -833,7 +833,7 @@ How can I free up space in Neptune?
 How do I upload my offline metadata to Neptune?
     You can upload the data stored on-disk with the following command (replace the workspace and project with your own):
         {bash}neptune sync -p workspace-name/project-name{end}
-If your subscription is based on logging hours, you're getting this error because you've run out of monitoring time.
+If your subscription is based on logging hours, you may also get this error if you've run out of monitoring time.
     To continue logging, you need to top up your logging hours or wait for your new monthly package.
 Learn more in the docs:
     - https://docs.neptune.ai/help/error_limit_exceeded/

--- a/src/neptune/exceptions.py
+++ b/src/neptune/exceptions.py
@@ -823,9 +823,9 @@ class NeptuneLimitExceedException(NeptuneException):
 {end}
 {reason}
 
-Data synchronization was interrupted because you're out of storage space. If you're using Neptune in asynchronous mode
-(default), the data that couldn't be uploaded is safely stored on the disk. You can still fetch and delete data from
-your project(s).
+Data synchronization was interrupted because you're out of storage space (or logging hours). If you're using Neptune in
+asynchronous mode (default), the data that couldn't be uploaded is safely stored on the disk.
+You can still fetch and delete data from your project(s).
 How can I free up space in Neptune?
     - Contact your workspace admin about possible project or workspace storage limits.
     - Upgrade your subscription with more storage: https://app.neptune.ai/-/subscription
@@ -833,6 +833,8 @@ How can I free up space in Neptune?
 How do I upload my offline metadata to Neptune?
     You can upload the data stored on-disk with the following command (replace the workspace and project with your own):
         {bash}neptune sync -p workspace-name/project-name{end}
+If your subscription is based on logging hours, you're getting this error because you've run out of monitoring time.
+    To continue logging, you need to top up your logging hours or wait for your new monthly package.
 Learn more in the docs:
     - https://docs.neptune.ai/help/error_limit_exceeded/
     - https://docs.neptune.ai/help/workspace_read_only/


### PR DESCRIPTION
Fix `NeptuneLimitExceedException` message to take logging hours into account.

## Before submitting checklist

- [x] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [x] Did you **ask the docs owner** to review all the user-facing changes?
