### PR TITLE
Add OperationsPreprocessor to queueing

### DIFF
--- a/src/neptune/internal/backends/hosted_neptune_backend.py
+++ b/src/neptune/internal/backends/hosted_neptune_backend.py
@@ -457,7 +457,7 @@ class HostedNeptuneBackend(NeptuneBackend):
         dropped_count = operations_batch.dropped_operations_count
 
         operations_preprocessor = OperationsPreprocessor()
-        operations_preprocessor.process(operations_batch.operations)
+        operations_preprocessor.process_batch(operations_batch.operations)
 
         preprocessed_operations = operations_preprocessor.get_operations()
         errors.extend(preprocessed_operations.errors)

--- a/src/neptune/internal/backends/operations_preprocessor.py
+++ b/src/neptune/internal/backends/operations_preprocessor.py
@@ -21,6 +21,7 @@ from enum import Enum
 from typing import (
     Callable,
     List,
+    Type,
     TypeVar,
 )
 
@@ -375,7 +376,7 @@ class _OperationsAccumulator(OperationVisitor[None]):
 
         return modifier
 
-    def _log_modifier(self, log_op_class: type[LogOperation], clear_op_class: type, log_combine: Callable[[T, T], T]):
+    def _log_modifier(self, log_op_class: Type[LogOperation], clear_op_class: type, log_combine: Callable[[T, T], T]):
         def modifier(ops: list[Operation], new_op: Operation):
             if len(ops) == 0:
                 res = [new_op]

--- a/src/neptune/internal/backends/operations_preprocessor.py
+++ b/src/neptune/internal/backends/operations_preprocessor.py
@@ -80,15 +80,21 @@ class OperationsPreprocessor:
         self.final_ops_count = 0
         self.final_append_count = 0
 
-    def process(self, operation: Operation) -> None:
-        self._process_op(operation)
-        self.processed_ops_count += 1
+    def process(self, operation: Operation) -> bool:
+        """Adds a single operation to its processed list.
+        Returns `False` iff the new operation can't be in queue until one of already enqueued operations gets submitted
+        to Leaderboard first.
+        """
+        try:
+            self._process_op(operation)
+            self.processed_ops_count += 1
+            return True
+        except RequiresPreviousCompleted:
+            return False
 
     def process_batch(self, operations: List[Operation]) -> None:
         for op in operations:
-            try:
-                self.process(op)
-            except RequiresPreviousCompleted:
+            if not self.process(op):
                 return
 
     def _process_op(self, op: Operation) -> "_OperationsAccumulator":

--- a/src/neptune/internal/backends/operations_preprocessor.py
+++ b/src/neptune/internal/backends/operations_preprocessor.py
@@ -72,6 +72,9 @@ class AccumulatedOperations:
 
     errors: List[MetadataInconsistency] = dataclasses.field(default_factory=list)
 
+    def all_operations(self) -> List[Operation]:
+        return self.upload_operations + self.artifact_operations + self.other_operations
+
 
 class OperationsPreprocessor:
     def __init__(self):

--- a/src/neptune/internal/backends/operations_preprocessor.py
+++ b/src/neptune/internal/backends/operations_preprocessor.py
@@ -374,7 +374,7 @@ class _OperationsAccumulator(OperationVisitor[None]):
         return lambda ops, new_op: [new_op]
 
     def _clear_modifier(self):
-        def modifier(ops: list[Operation], new_op: Operation):
+        def modifier(ops: List[Operation], new_op: Operation):
             for op in ops:
                 if isinstance(op, LogOperation):
                     self._append_count -= op.value_count()
@@ -383,7 +383,7 @@ class _OperationsAccumulator(OperationVisitor[None]):
         return modifier
 
     def _log_modifier(self, log_op_class: Type[LogOperation], clear_op_class: type, log_combine: Callable[[T, T], T]):
-        def modifier(ops: list[Operation], new_op: Operation):
+        def modifier(ops: List[Operation], new_op: Operation):
             if len(ops) == 0:
                 res = [new_op]
             elif len(ops) == 1 and isinstance(ops[0], log_op_class):

--- a/src/neptune/internal/backends/operations_preprocessor.py
+++ b/src/neptune/internal/backends/operations_preprocessor.py
@@ -82,8 +82,8 @@ class OperationsPreprocessor:
 
     def process(self, operation: Operation) -> bool:
         """Adds a single operation to its processed list.
-        Returns `False` iff the new operation can't be in queue until one of already enqueued operations gets submitted
-        to Leaderboard first.
+        Returns `False` iff the new operation can't be in queue until one of already enqueued operations gets
+        synchronized with server first.
         """
         try:
             self._process_op(operation)

--- a/src/neptune/internal/backends/operations_preprocessor.py
+++ b/src/neptune/internal/backends/operations_preprocessor.py
@@ -44,6 +44,7 @@ from neptune.internal.operation import (
     DeleteFiles,
     LogFloats,
     LogImages,
+    LogOperation,
     LogStrings,
     Operation,
     RemoveStrings,
@@ -75,19 +76,27 @@ class OperationsPreprocessor:
     def __init__(self):
         self._accumulators: typing.Dict[str, "_OperationsAccumulator"] = dict()
         self.processed_ops_count = 0
+        self.final_ops_count = 0
+        self.final_append_count = 0
 
-    def process(self, operations: List[Operation]):
+    def process(self, operation: Operation) -> None:
+        self._process_op(operation)
+        self.processed_ops_count += 1
+
+    def process_batch(self, operations: List[Operation]) -> None:
         for op in operations:
             try:
-                self._process_op(op)
-                self.processed_ops_count += 1
+                self.process(op)
             except RequiresPreviousCompleted:
                 return
 
     def _process_op(self, op: Operation) -> "_OperationsAccumulator":
         path_str = path_to_str(op.path)
         target_acc = self._accumulators.setdefault(path_str, _OperationsAccumulator(op.path))
+        old_ops_count, old_append_count = target_acc.get_op_count(), target_acc.get_append_count()
         target_acc.visit(op)
+        self.final_ops_count += target_acc.get_op_count() - old_ops_count
+        self.final_append_count += target_acc.get_append_count() - old_append_count
         return target_acc
 
     @staticmethod
@@ -143,12 +152,20 @@ class _OperationsAccumulator(OperationVisitor[None]):
         self._modify_ops = []
         self._config_ops = []
         self._errors = []
+        self._ops_count = 0
+        self._append_count = 0
 
     def get_operations(self) -> List[Operation]:
         return self._delete_ops + self._modify_ops + self._config_ops
 
     def get_errors(self) -> List[MetadataInconsistency]:
         return self._errors
+
+    def get_op_count(self) -> int:
+        return self._ops_count
+
+    def get_append_count(self) -> int:
+        return self._append_count
 
     def _check_prerequisites(self, op: Operation):
         if (OperationsPreprocessor.is_file_op(op) or OperationsPreprocessor.is_artifact_op(op)) and len(
@@ -179,7 +196,9 @@ class _OperationsAccumulator(OperationVisitor[None]):
         else:
             self._check_prerequisites(op)
             self._type = expected_type
+            old_op_count = len(self._modify_ops)
             self._modify_ops = modifier(self._modify_ops, op)
+            self._ops_count += len(self._modify_ops) - old_op_count
 
     def _process_config_op(self, expected_type: _DataType, op: Operation) -> None:
 
@@ -199,7 +218,9 @@ class _OperationsAccumulator(OperationVisitor[None]):
         else:
             self._check_prerequisites(op)
             self._type = expected_type
+            old_op_count = len(self._config_ops)
             self._config_ops = [op]
+            self._ops_count += len(self._config_ops) - old_op_count
 
     def visit_assign_float(self, op: AssignFloat) -> None:
         self._process_modify_op(_DataType.FLOAT, op, self._assign_modifier())
@@ -295,6 +316,8 @@ class _OperationsAccumulator(OperationVisitor[None]):
                 self._modify_ops = []
                 self._config_ops = []
                 self._type = None
+                self._ops_count = len(self._delete_ops)
+                self._append_count = 0
             else:
                 # This case is tricky. There was no delete operation, but some modifications was performed.
                 # We do not know if this attribute exists on server side and we do not want a delete op to fail.
@@ -303,6 +326,8 @@ class _OperationsAccumulator(OperationVisitor[None]):
                 self._modify_ops = []
                 self._config_ops = []
                 self._type = None
+                self._ops_count = len(self._delete_ops)
+                self._append_count = 0
         else:
             if self._delete_ops:
                 # Do nothing if there already is a delete operation
@@ -312,6 +337,7 @@ class _OperationsAccumulator(OperationVisitor[None]):
                 # If value has not been set locally yet and no delete operation was performed,
                 # simply perform single delete operation.
                 self._delete_ops.append(op)
+                self._ops_count = len(self._delete_ops)
 
     @staticmethod
     def _artifact_log_modifier(
@@ -340,23 +366,30 @@ class _OperationsAccumulator(OperationVisitor[None]):
     def _assign_modifier():
         return lambda ops, new_op: [new_op]
 
-    @staticmethod
-    def _clear_modifier():
-        return lambda ops, new_op: [new_op]
+    def _clear_modifier(self):
+        def modifier(ops: list[Operation], new_op: Operation):
+            for op in ops:
+                if isinstance(op, LogOperation):
+                    self._append_count -= op.value_count()
+            return [new_op]
 
-    @staticmethod
-    def _log_modifier(log_op_class: type, clear_op_class: type, log_combine: Callable[[T, T], T]):
-        def modifier(ops, new_op):
+        return modifier
+
+    def _log_modifier(self, log_op_class: type[LogOperation], clear_op_class: type, log_combine: Callable[[T, T], T]):
+        def modifier(ops: list[Operation], new_op: Operation):
             if len(ops) == 0:
-                return [new_op]
+                res = [new_op]
             elif len(ops) == 1 and isinstance(ops[0], log_op_class):
-                return [log_combine(ops[0], new_op)]
+                res = [log_combine(ops[0], new_op)]
             elif len(ops) == 1 and isinstance(ops[0], clear_op_class):
-                return [ops[0], new_op]
+                res = [ops[0], new_op]
             elif len(ops) == 2:
-                return [ops[0], log_combine(ops[1], new_op)]
+                res = [ops[0], log_combine(ops[1], new_op)]
             else:
                 raise InternalClientError("Preprocessing operations failed: len(ops) == {}".format(len(ops)))
+            if isinstance(new_op, log_op_class):  # Check just so that static typing doesn't complain
+                self._append_count += new_op.value_count()
+            return res
 
         return modifier
 

--- a/src/neptune/internal/operation.py
+++ b/src/neptune/internal/operation.py
@@ -292,7 +292,9 @@ class UploadFileSet(Operation):
 
 
 class LogOperation(Operation, abc.ABC):
-    pass
+    @abc.abstractmethod
+    def value_count(self) -> int:
+        pass
 
 
 @dataclass
@@ -332,6 +334,9 @@ class LogFloats(LogOperation):
             [LogFloats.ValueType.from_dict(value) for value in data["values"]],
         )
 
+    def value_count(self) -> int:
+        return len(self.values)
+
 
 @dataclass
 class LogStrings(LogOperation):
@@ -354,6 +359,9 @@ class LogStrings(LogOperation):
             data["path"],
             [LogStrings.ValueType.from_dict(value) for value in data["values"]],
         )
+
+    def value_count(self) -> int:
+        return len(self.values)
 
 
 @dataclass
@@ -399,6 +407,9 @@ class LogImages(LogOperation):
             data["path"],
             [LogImages.ValueType.from_dict(value, ImageValue.deserializer) for value in data["values"]],
         )
+
+    def value_count(self) -> int:
+        return len(self.values)
 
 
 @dataclass

--- a/src/neptune/internal/operation_processors/async_operation_processor.py
+++ b/src/neptune/internal/operation_processors/async_operation_processor.py
@@ -26,7 +26,7 @@ from time import (
 )
 from typing import (
     Callable,
-    Final,
+    ClassVar,
     List,
     Optional,
     Tuple,
@@ -261,9 +261,9 @@ class AsyncOperationProcessor(OperationProcessor):
         self._queue.close()
 
     class ConsumerThread(Daemon):
-        MAX_OPERATIONS_IN_BATCH: Final[int] = 1000
-        MAX_APPENDS_IN_BATCH: Final[int] = 100000
-        MAX_BATCH_SIZE_BYTES: Final[int] = 100 * 1024 * 1024
+        MAX_OPERATIONS_IN_BATCH: ClassVar[int] = 1000
+        MAX_APPENDS_IN_BATCH: ClassVar[int] = 100000
+        MAX_BATCH_SIZE_BYTES: ClassVar[int] = 100 * 1024 * 1024
 
         def __init__(
             self,

--- a/src/neptune/internal/operation_processors/async_operation_processor.py
+++ b/src/neptune/internal/operation_processors/async_operation_processor.py
@@ -318,7 +318,7 @@ class AsyncOperationProcessor(OperationProcessor):
                 else:
                     self._last_disk_record = record
                     break
-            return (preprocessor.get_operations(), version) if version is not None else None
+            return (preprocessor.get_operations().all_operations(), version) if version is not None else None
 
         def _check_no_progress(self):
             if not self._no_progress_exceeded:

--- a/src/neptune/internal/threading/daemon.py
+++ b/src/neptune/internal/threading/daemon.py
@@ -96,9 +96,6 @@ class Daemon(threading.Thread):
                     with self._wait_condition:
                         if self._sleep_time > 0 and self._state == Daemon.DaemonState.WORKING:
                             self._wait_condition.wait(timeout=self._sleep_time)
-        except Exception as ex:
-            print("ERROR IN DAEMON:", ex)
-            raise ex
         finally:
             with self._wait_condition:
                 self._state = Daemon.DaemonState.STOPPED

--- a/src/neptune/internal/threading/daemon.py
+++ b/src/neptune/internal/threading/daemon.py
@@ -96,6 +96,9 @@ class Daemon(threading.Thread):
                     with self._wait_condition:
                         if self._sleep_time > 0 and self._state == Daemon.DaemonState.WORKING:
                             self._wait_condition.wait(timeout=self._sleep_time)
+        except Exception as ex:
+            print("ERROR IN DAEMON:", ex)
+            raise ex
         finally:
             with self._wait_condition:
                 self._state = Daemon.DaemonState.STOPPED

--- a/tests/unit/neptune/new/internal/backends/test_operations_preprocessor.py
+++ b/tests/unit/neptune/new/internal/backends/test_operations_preprocessor.py
@@ -61,7 +61,7 @@ class TestOperationsPreprocessor(TestAttributeBase):
         ]
 
         # when
-        processor.process(operations)
+        processor.process_batch(operations)
 
         # then
         result = processor.get_operations()
@@ -101,7 +101,7 @@ class TestOperationsPreprocessor(TestAttributeBase):
         ]
 
         # when
-        processor.process(operations)
+        processor.process_batch(operations)
 
         # then
         result = processor.get_operations()
@@ -160,7 +160,7 @@ class TestOperationsPreprocessor(TestAttributeBase):
         ]
 
         # when
-        processor.process(operations)
+        processor.process_batch(operations)
 
         # then
         result = processor.get_operations()
@@ -231,7 +231,7 @@ class TestOperationsPreprocessor(TestAttributeBase):
         ]
 
         # when
-        processor.process(operations)
+        processor.process_batch(operations)
 
         # then
         result = processor.get_operations()
@@ -283,7 +283,7 @@ class TestOperationsPreprocessor(TestAttributeBase):
         ]
 
         # when
-        processor.process(operations)
+        processor.process_batch(operations)
 
         # then
         result = processor.get_operations()
@@ -328,25 +328,25 @@ class TestOperationsPreprocessor(TestAttributeBase):
         ]
 
         # when
-        processor.process(operations)
+        processor.process_batch(operations)
 
         # then: there's a cutoff after DeleteAttribute(["a"])
         result = processor.get_operations()
         self.assertEqual(
-            result.upload_operations,
             [
                 UploadFileSet(["b"], ["abc", "defgh"], reset=True),
                 UploadFileSet(["c"], ["abc", "defgh"], reset=True),
                 UploadFileSet(["c"], ["qqq"], reset=False),
                 UploadFileSet(["d"], ["hhh", "gij"], reset=False),
             ],
+            result.upload_operations,
         )
         self.assertEqual(result.artifact_operations, [])
         self.assertEqual(
-            result.other_operations,
             [
                 DeleteAttribute(["a"]),
             ],
+            result.other_operations,
         )
         self.assertEqual(result.errors, [])
         self.assertEqual(processor.processed_ops_count, 6)
@@ -375,7 +375,7 @@ class TestOperationsPreprocessor(TestAttributeBase):
         ]
 
         # when
-        processor.process(operations)
+        processor.process_batch(operations)
 
         # then: there's a cutoff before second TrackFilesToArtifact(["a"]) due to DeleteAttribute(["a"])
         result = processor.get_operations()


### PR DESCRIPTION
Adding OperationsPreprocessor to AsyncOperationProcessor so that:
* number of actual (efficiently combined) operations can be used to limit the size of a batch,
* number of series appends can be used to limit the size of a batch.