### PR TITLE
clarify MetadataContainerNotFound message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Updated NeptuneModelKeyAlreadyExistsError exception message ([#1536](https://github.com/neptune-ai/neptune-client/pull/1536))
 - Sample logging for series errors ([#1539](https://github.com/neptune-ai/neptune-client/pull/1539))
 - Added support for unsupported float values in `stringify_unsupported()` ([#1543](https://github.com/neptune-ai/neptune-client/pull/1543))
+- Clarified message shown when nonexistent ID is passed to `with_id` argument ([#1551](https://github.com/neptune-ai/neptune-client/pull/1551))
 
 ### Changes
 - Allow to disable deletion of local parent folder ([#1511](https://github.com/neptune-ai/neptune-client/pull/1511))

--- a/src/neptune/exceptions.py
+++ b/src/neptune/exceptions.py
@@ -206,7 +206,7 @@ class MetadataContainerNotFound(NeptuneException):
         self.container_id = container_id
         self.container_type = container_type
         container_type_str = container_type.value.capitalize() if container_type else "object"
-        super().__init__("{} {} not found.".format(container_type_str, container_id))
+        super().__init__(f"No existing {container_type_str} was found at {container_id}.")
 
     @classmethod
     def of_container_type(cls, container_type: Optional[ContainerType], container_id: str):


### PR DESCRIPTION
Clarifies the `MetadataContainerNotFound` exception message.
The current message can be difficult to understand if the user has mistakenly passed a custom/new ID to `with_id`. (Addresses https://github.com/neptune-ai/neptune-client/issues/1541)

## Before submitting checklist

- [ ] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
