### PR TITLE
Use literals instead of str for Mode typing and `typing-extensions` added as a direct requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [UNRELEASED] 1.8.7
+
+### Changes
+- Use literals instead of str for Mode typing ([#1586](https://github.com/neptune-ai/neptune-client/pull/1586))
+
+
 ## 1.8.6
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [UNRELEASED] 1.8.7
 
+### Fixes
+- Add direct requirement of `typing-extensions` ([#1586](https://github.com/neptune-ai/neptune-client/pull/1586))
+
 ### Changes
 - Use literals instead of str for Mode typing ([#1586](https://github.com/neptune-ai/neptune-client/pull/1586))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ python = "^3.7"
 
 # Python lack of functionalities from future versions
 importlib-metadata = { version = "*", python = "<3.8" }
+typing-extensions = ">=3.10.0"
 
 # Missing compatibility layer between Python 2 and Python 3
 six = ">=1.12.0"

--- a/src/neptune/metadata_containers/model.py
+++ b/src/neptune/metadata_containers/model.py
@@ -20,6 +20,7 @@ from typing import (
     TYPE_CHECKING,
     Iterable,
     List,
+    Literal,
     Optional,
 )
 
@@ -166,7 +167,7 @@ class Model(MetadataContainer):
         key: Optional[str] = None,
         project: Optional[str] = None,
         api_token: Optional[str] = None,
-        mode: Optional[str] = None,
+        mode: Optional[Literal["async", "sync", "read-only", "debug"]] = None,
         flush_period: float = DEFAULT_FLUSH_PERIOD,
         proxies: Optional[dict] = None,
         async_lag_callback: Optional[NeptuneObjectCallback] = None,

--- a/src/neptune/metadata_containers/model.py
+++ b/src/neptune/metadata_containers/model.py
@@ -91,7 +91,7 @@ class Model(MetadataContainer):
         mode: Connection mode in which the tracking will work.
             If `None` (default), the value of the NEPTUNE_MODE environment variable is used.
             If no value was set for the environment variable, "async" is used by default.
-            Possible values are `async`, `sync`, `offline`, `read-only`, and `debug`.
+            Possible values are `async`, `sync`, `read-only`, and `debug`.
         flush_period: In the asynchronous (default) connection mode, how often disk flushing is triggered
             (in seconds).
         proxies: Argument passed to HTTP calls made via the Requests library, as dictionary of strings.

--- a/src/neptune/metadata_containers/model.py
+++ b/src/neptune/metadata_containers/model.py
@@ -20,9 +20,10 @@ from typing import (
     TYPE_CHECKING,
     Iterable,
     List,
-    Literal,
     Optional,
 )
+
+from typing_extensions import Literal
 
 from neptune.attributes.constants import SYSTEM_NAME_ATTRIBUTE_PATH
 from neptune.common.exceptions import NeptuneException

--- a/src/neptune/metadata_containers/model_version.py
+++ b/src/neptune/metadata_containers/model_version.py
@@ -19,6 +19,7 @@ import os
 from typing import (
     TYPE_CHECKING,
     List,
+    Literal,
     Optional,
 )
 
@@ -166,7 +167,7 @@ class ModelVersion(MetadataContainer):
         model: Optional[str] = None,
         project: Optional[str] = None,
         api_token: Optional[str] = None,
-        mode: Optional[str] = None,
+        mode: Optional[Literal["async", "sync", "read-only", "debug"]] = None,
         flush_period: float = DEFAULT_FLUSH_PERIOD,
         proxies: Optional[dict] = None,
         async_lag_callback: Optional[NeptuneObjectCallback] = None,

--- a/src/neptune/metadata_containers/model_version.py
+++ b/src/neptune/metadata_containers/model_version.py
@@ -88,7 +88,7 @@ class ModelVersion(MetadataContainer):
         mode: Connection mode in which the tracking will work.
             If None (default), the value of the NEPTUNE_MODE environment variable is used.
             If no value was set for the environment variable, "async" is used by default.
-            Possible values are `async`, `sync`, `offline`, `read-only`, and `debug`.
+            Possible values are `async`, `sync`, `read-only`, and `debug`.
         flush_period: In the asynchronous (default) connection mode, how often disk flushing is triggered
             (in seconds).
         proxies: Argument passed to HTTP calls made via the Requests library, as dictionary of strings.

--- a/src/neptune/metadata_containers/model_version.py
+++ b/src/neptune/metadata_containers/model_version.py
@@ -19,9 +19,10 @@ import os
 from typing import (
     TYPE_CHECKING,
     List,
-    Literal,
     Optional,
 )
+
+from typing_extensions import Literal
 
 from neptune.attributes.constants import (
     SYSTEM_NAME_ATTRIBUTE_PATH,

--- a/src/neptune/metadata_containers/project.py
+++ b/src/neptune/metadata_containers/project.py
@@ -73,7 +73,7 @@ class Project(MetadataContainer):
         mode: Connection mode in which the tracking will work.
             If left empty, the value of the NEPTUNE_MODE environment variable is used.
             If no value was set for the environment variable, "async" is used by default.
-            Possible values are `async`, `sync`, `offline`, `read-only`, and `debug`.
+            Possible values are `async`, `sync`, `read-only`, and `debug`.
         flush_period: In the asynchronous (default) connection mode, how often disk flushing is triggered.
             Defaults to 5 (every 5 seconds).
         proxies: Argument passed to HTTP calls made via the Requests library, as dictionary of strings.

--- a/src/neptune/metadata_containers/project.py
+++ b/src/neptune/metadata_containers/project.py
@@ -18,6 +18,7 @@ __all__ = ["Project"]
 import os
 from typing import (
     Iterable,
+    Literal,
     Optional,
     Union,
 )
@@ -136,7 +137,7 @@ class Project(MetadataContainer):
         project: Optional[str] = None,
         *,
         api_token: Optional[str] = None,
-        mode: Optional[str] = None,
+        mode: Optional[Literal["async", "sync", "read-only", "debug"]] = None,
         flush_period: float = DEFAULT_FLUSH_PERIOD,
         proxies: Optional[dict] = None,
         async_lag_callback: Optional[NeptuneObjectCallback] = None,

--- a/src/neptune/metadata_containers/project.py
+++ b/src/neptune/metadata_containers/project.py
@@ -18,10 +18,11 @@ __all__ = ["Project"]
 import os
 from typing import (
     Iterable,
-    Literal,
     Optional,
     Union,
 )
+
+from typing_extensions import Literal
 
 from neptune.common.exceptions import NeptuneException
 from neptune.envs import CONNECTION_MODE

--- a/src/neptune/metadata_containers/run.py
+++ b/src/neptune/metadata_containers/run.py
@@ -21,6 +21,7 @@ from platform import node as get_hostname
 from typing import (
     TYPE_CHECKING,
     List,
+    Literal,
     Optional,
     Tuple,
     Union,
@@ -309,7 +310,7 @@ class Run(MetadataContainer):
         project: Optional[str] = None,
         api_token: Optional[str] = None,
         custom_run_id: Optional[str] = None,
-        mode: Optional[str] = None,
+        mode: Optional[Literal["async", "sync", "offline", "read-only", "debug"]] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
         tags: Optional[Union[List[str], str]] = None,

--- a/src/neptune/metadata_containers/run.py
+++ b/src/neptune/metadata_containers/run.py
@@ -21,11 +21,12 @@ from platform import node as get_hostname
 from typing import (
     TYPE_CHECKING,
     List,
-    Literal,
     Optional,
     Tuple,
     Union,
 )
+
+from typing_extensions import Literal
 
 from neptune.attributes.constants import (
     SYSTEM_DESCRIPTION_ATTRIBUTE_PATH,


### PR DESCRIPTION
## Summary

- Closes https://github.com/neptune-ai/neptune-client/issues/1335
- Adds a direct requirement of `typing-extensions`
- Makes more visible what modes are available when trying to initialize specific Neptune Objects with a usage of `Literal` typing.

Remember to adjust conda requirements as well after release.

---
## Before submitting checklist

- [x] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [x] Did you **ask the docs owner** to review all the user-facing changes?
