### PR TITLE
Changed format of warning messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Use the same logger instance for logging ([#1611](https://github.com/neptune-ai/neptune-client/pull/1611))
 - Changed offline directories internal path structure ([#1606](https://github.com/neptune-ai/neptune-client/pull/1606))
 - Changed internal directories path structure ([#1606](https://github.com/neptune-ai/neptune-client/pull/1606))
+- Changed format of warning messages ([#1635](https://github.com/neptune-ai/neptune-client/pull/1635))
 
 
 ## 1.8.6

--- a/src/neptune/common/warnings.py
+++ b/src/neptune/common/warnings.py
@@ -87,12 +87,14 @@ def warn_once(message: str, *, exception: type(Exception) = None):
         message_hash = hash(message)
 
         if message_hash not in warned_once:
+            old_formatting = warnings.formatwarning
             warnings.formatwarning = format_message
             warnings.warn(
                 message=message,
                 category=exception,
                 stacklevel=get_user_code_stack_level(),
             )
+            warnings.formatwarning = old_formatting
             warned_once.add(message_hash)
 
 

--- a/src/neptune/common/warnings.py
+++ b/src/neptune/common/warnings.py
@@ -27,6 +27,11 @@ import traceback
 import warnings
 
 import neptune
+from neptune.internal.utils.logger import NEPTUNE_LOGGER_NAME
+from neptune.internal.utils.runningmode import in_interactive
+
+DEFAULT_FORMAT = "[%(name)s] [warning] %(filename)s:%(lineno)d: %(category)s: %(message)s\n"
+INTERACTIVE_FORMAT = "[%(name)s] [warning] %(category)s: %(message)s\n"
 
 
 class NeptuneDeprecationWarning(DeprecationWarning):
@@ -60,6 +65,20 @@ def get_user_code_stack_level():
     return 2
 
 
+def format_message(message, category, filename, lineno, line=None) -> str:
+    variables = {
+        "message": message,
+        "category": category.__name__,
+        "filename": filename,
+        "lineno": lineno,
+        "name": NEPTUNE_LOGGER_NAME,
+    }
+
+    message_format = INTERACTIVE_FORMAT if in_interactive() else DEFAULT_FORMAT
+
+    return message_format % variables
+
+
 def warn_once(message: str, *, exception: type(Exception) = None):
     if len(warned_once) < MAX_WARNED_ONCE_CAPACITY:
         if exception is None:
@@ -68,6 +87,7 @@ def warn_once(message: str, *, exception: type(Exception) = None):
         message_hash = hash(message)
 
         if message_hash not in warned_once:
+            warnings.formatwarning = format_message
             warnings.warn(
                 message=message,
                 category=exception,


### PR DESCRIPTION
New format:
```bash
[neptune] [warning] /Users/neptune/Library/Application Support/JetBrains/PyCharm2023.3/scratches/scratch_11.py:1: NeptuneDeprecationWarning: You're importing the Neptune client library via the deprecated `neptune.new` module, which will be removed in a future release. Import directly from `neptune` instead.
```

## Before submitting checklist

- [x] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
