### PR TITLE
Restored support for SSL verification exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [UNRELEASED] neptune 1.9.2
+
+### Fixes
+- Restored support for SSL verification exception ([#1661](https://github.com/neptune-ai/neptune-client/pull/1661))
+
+
 ## neptune 1.9.1
 
 ### Fixes

--- a/src/neptune/common/backends/utils.py
+++ b/src/neptune/common/backends/utils.py
@@ -44,8 +44,10 @@ from neptune.common.exceptions import (
     NeptuneAuthTokenExpired,
     NeptuneConnectionLostException,
     NeptuneInvalidApiTokenException,
+    NeptuneSSLVerificationError,
     Unauthorized,
 )
+from neptune.common.utils import reset_internal_ssl_state
 from neptune.internal.utils.logger import get_logger
 
 _logger = get_logger()
@@ -66,6 +68,7 @@ def get_retry_from_headers_or_default(headers, retry_count):
 
 def with_api_exceptions_handler(func):
     def wrapper(*args, **kwargs):
+        ssl_error_occurred = False
         last_exception = None
         start_time = time.monotonic()
         for retry in itertools.count(0):
@@ -78,6 +81,27 @@ def with_api_exceptions_handler(func):
                 if "X-Neptune-Api-Token" in e.args[0]:
                     raise NeptuneInvalidApiTokenException()
                 raise
+            except requests.exceptions.SSLError as e:
+                """
+                OpenSSL's internal random number generator does not properly handle forked processes.
+                Applications must change the PRNG state of the parent process
+                if they use any SSL feature with os.fork().
+                Any successful call of RAND_add(), RAND_bytes() or RAND_pseudo_bytes() is sufficient.
+                https://docs.python.org/3/library/ssl.html#multi-processing
+                On Linux it looks like it does not help much but does not break anything either.
+                But single retry seems to solve the issue.
+                """
+                if not ssl_error_occurred:
+                    ssl_error_occurred = True
+                    reset_internal_ssl_state()
+                    continue
+
+                if "CertificateError" in str(e.__context__):
+                    raise NeptuneSSLVerificationError() from e
+                else:
+                    time.sleep(min(2 ** min(MAX_RETRY_MULTIPLIER, retry), MAX_RETRY_TIME))
+                    last_exception = e
+                    continue
             except (
                 BravadoConnectionError,
                 BravadoTimeoutError,
@@ -90,7 +114,6 @@ def with_api_exceptions_handler(func):
                 HTTPInternalServerError,
                 NewConnectionError,
                 ChunkedEncodingError,
-                requests.exceptions.SSLError,
                 RecursiveCallException,
             ) as e:
                 time.sleep(min(2 ** min(MAX_RETRY_MULTIPLIER, retry), MAX_RETRY_TIME))


### PR DESCRIPTION
It was removed in https://github.com/neptune-ai/neptune-client/releases/tag/1.8.1

## Before submitting checklist

- [x] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [ ] Did you **ask the docs owner** to review all the user-facing changes?
