### PR TITLE
change handling of too long custom run id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Added support for enhanced field definitions querying ([#1751](https://github.com/neptune-ai/neptune-client/pull/1751))
 - Added initial operations to the `core.operations` package ([#1759](https://github.com/neptune-ai/neptune-client/pull/1759))
 - Move some `OperationProcessor` implementations to `neptune.core.operation_processors` ([#1760](https://github.com/neptune-ai/neptune-client/pull/1760))
+- Changed handling of too long custom run id ([#1761](https://github.com/neptune-ai/neptune-client/pull/1761))
 
 ### Fixes
 - Fixed `tqdm.notebook` import only in Notebook environment ([#1716](https://github.com/neptune-ai/neptune-client/pull/1716))

--- a/src/neptune/internal/utils/limits.py
+++ b/src/neptune/internal/utils/limits.py
@@ -22,20 +22,14 @@ from neptune.internal.utils.logger import get_logger
 _logger = get_logger()
 
 
-_CUSTOM_RUN_ID_LENGTH = 36
+CUSTOM_RUN_ID_LENGTH = 128
 _LOGGED_IMAGE_SIZE_LIMIT_MB = 32
 
 BYTES_IN_MB = 1024 * 1024
 
 
 def custom_run_id_exceeds_length(custom_run_id):
-    if custom_run_id and len(custom_run_id) > _CUSTOM_RUN_ID_LENGTH:
-        _logger.warning(
-            "Given custom_run_id exceeds %s" " characters and it will be ignored.",
-            _CUSTOM_RUN_ID_LENGTH,
-        )
-        return True
-    return False
+    return custom_run_id and len(custom_run_id) > CUSTOM_RUN_ID_LENGTH
 
 
 def image_size_exceeds_limit_for_logging(content_size):

--- a/src/neptune/objects/run.py
+++ b/src/neptune/objects/run.py
@@ -47,6 +47,7 @@ from neptune.envs import (
 from neptune.exceptions import (
     InactiveRunException,
     NeedExistingRunForReadOnlyMode,
+    NeptuneException,
     NeptuneRunResumeAndCustomIdCollision,
 )
 from neptune.internal.backends.api_model import ApiExperiment
@@ -80,7 +81,10 @@ from neptune.internal.utils.git import (
     track_uncommitted_changes,
 )
 from neptune.internal.utils.hashing import generate_hash
-from neptune.internal.utils.limits import custom_run_id_exceeds_length
+from neptune.internal.utils.limits import (
+    CUSTOM_RUN_ID_LENGTH,
+    custom_run_id_exceeds_length,
+)
 from neptune.internal.utils.ping_background_job import PingBackgroundJob
 from neptune.internal.utils.runningmode import (
     in_interactive,
@@ -432,7 +436,9 @@ class Run(NeptuneObject):
 
             custom_run_id = self._custom_run_id
             if custom_run_id_exceeds_length(self._custom_run_id):
-                custom_run_id = None
+                raise NeptuneException(
+                    f"Given custom_run_id exceeds {CUSTOM_RUN_ID_LENGTH} characters and it will be ignored."
+                )
 
             notebook_id, checkpoint_id = create_notebook_checkpoint(backend=self._backend)
 

--- a/src/neptune/objects/run.py
+++ b/src/neptune/objects/run.py
@@ -436,9 +436,7 @@ class Run(NeptuneObject):
 
             custom_run_id = self._custom_run_id
             if custom_run_id_exceeds_length(self._custom_run_id):
-                raise NeptuneException(
-                    f"Given custom_run_id exceeds {CUSTOM_RUN_ID_LENGTH} characters and it will be ignored."
-                )
+                raise NeptuneException(f"Parameter `custom_run_id` exceeds {CUSTOM_RUN_ID_LENGTH} characters.")
 
             notebook_id, checkpoint_id = create_notebook_checkpoint(backend=self._backend)
 

--- a/tests/unit/neptune/new/client/test_run.py
+++ b/tests/unit/neptune/new/client/test_run.py
@@ -37,7 +37,10 @@ from neptune.envs import (
     API_TOKEN_ENV_NAME,
     PROJECT_ENV_NAME,
 )
-from neptune.exceptions import MissingFieldException
+from neptune.exceptions import (
+    MissingFieldException,
+    NeptuneException,
+)
 from neptune.internal.backends.neptune_backend_mock import NeptuneBackendMock
 from neptune.internal.utils.paths import path_to_str
 from neptune.internal.utils.utils import IS_WINDOWS
@@ -304,3 +307,7 @@ class TestClientRun(AbstractExperimentTestMixin, unittest.TestCase):
                 capture_hardware_metrics=chm,
             ) as run:
                 assert run.exists("monitoring")
+
+    def test_too_long_custom_run_id_handling(self):
+        with self.assertRaises(NeptuneException):
+            init_run(mode="debug", custom_run_id="a" * 129)

--- a/tests/unit/neptune/new/client/test_run.py
+++ b/tests/unit/neptune/new/client/test_run.py
@@ -308,6 +308,15 @@ class TestClientRun(AbstractExperimentTestMixin, unittest.TestCase):
             ) as run:
                 assert run.exists("monitoring")
 
-    def test_too_long_custom_run_id_handling(self):
-        with self.assertRaises(NeptuneException):
-            init_run(mode="debug", custom_run_id="a" * 129)
+    def test_custom_run_id_handling(self):
+        lengths = [128, 129]
+        valid = [True, False]
+
+        for is_valid, length in zip(valid, lengths):
+            with self.subTest(is_valid=is_valid, length=length):
+                custom_run_id = "a" * length
+                if is_valid:
+                    init_run(mode="debug", custom_run_id=custom_run_id)
+                else:
+                    with self.assertRaises(NeptuneException):
+                        init_run(mode="debug", custom_run_id=custom_run_id)


### PR DESCRIPTION
when too long raise NeptuneException
max length increased to 128

## Before submitting checklist

- [x] Did you **update the CHANGELOG**? (not for test updates, internal changes/refactors or CI/CD setup)
- [x] Did you **ask the docs owner** to review all the user-facing changes?
